### PR TITLE
Fix a bug in the uniform continuous distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 v0.8.0
  - `cdf(x)`, `pdf(x)` and `pmf(x)` now return the correct value instead of panicking when `x` is outside the range of values that the distribution can attain.
- - Partially fixed a bug in the `Uniform` distribution implementation where samples were drawn from range `[min, max + 1)` instead of `[min, max]`. The samples are now drawn from range `[min, max)`.
+ - Fixed a bug in the `Uniform` distribution implementation where samples were drawn from range `[min, max + 1)` instead of `[min, max]`. The samples are now drawn correctly from the range `[min, max]`.
 
 v0.7.0
  - Implemented `Categorical` distribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v0.8.0
- - `cdf(x)`, `pdf(x)` and `pmf(x)` now return the correct value instead of panicking when `x` is outside the range of values that the distribution can attain. 
+ - `cdf(x)`, `pdf(x)` and `pmf(x)` now return the correct value instead of panicking when `x` is outside the range of values that the distribution can attain.
+ - Partially fixed a bug in the `Uniform` distribution implementation where samples were drawn from range `[min, max + 1)` instead of `[min, max]`. The samples are now drawn from range `[min, max)`.
 
 v0.7.0
  - Implemented `Categorical` distribution
@@ -72,7 +73,7 @@ v0.3.0
 - `Mean`, `Variance`, `Entropy`, `Skewness`, `Median`, and `Mode` no longer depend on `Distribution` trait
 - `Mean`, `Variance`, `Skewness`, and `Mode` are now generic over only one type, the return type, due to not depending on `Distribution` anymore
 - `order_statistic`, `median`, `quantile`, `percentile`, `lower_quartile`, `upper_quartile`, `interquartile_range`, and `ranks` methods removed
-    from `Statistics` trait. 
+    from `Statistics` trait.
 - `min`, `max`, `mean`, `variance`, and `std_dev` methods added to `Statistics` trait
 - `Statistics` trait now implemented for all types implementing `IntoIterator` where `Item` implements `Borrow<f64>`. Slice now implicitly implements
     `Statistics` through this new implementation.

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -466,7 +466,7 @@ mod test {
     }
 
     #[test]
-    fn test_in_range() {
+    fn test_samples_in_range() {
         use super::Distribution;
 
         use rand::{StdRng, SeedableRng};

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -473,9 +473,9 @@ mod test {
         let seed: &[_] = &[1, 2, 3, 4, 5];
         let mut r: StdRng = SeedableRng::from_seed(seed);
 
-        let min = -4.2;
-        let max = 0.42;
-        let num_trials = 1000;
+        let min = -0.5;
+        let max = 0.5;
+        let num_trials = 10_000;
         let n = try_create(min, max);
 
         assert!((0..num_trials)

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -464,4 +464,22 @@ mod test {
         test::check_continuous_distribution(&try_create(0.0, 10.0), 0.0, 10.0);
         test::check_continuous_distribution(&try_create(-2.0, 15.0), -2.0, 15.0);
     }
+
+    #[test]
+    fn test_in_range() {
+        use super::Distribution;
+
+        use rand::StdRng;
+        let mut r = StdRng::new().unwrap();
+
+        let min = -4.2;
+        let max = 0.42;
+        let num_trials = 1000;
+        let n = try_create(min, max);
+
+        assert!((0..num_trials)
+            .map(|_| n.sample::<StdRng>(&mut r))
+            .all(|v| (min <= v) && (v < max))
+        );
+    }
 }

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -92,7 +92,7 @@ impl Distribution<f64> for Uniform {
     /// # }
     /// ```
     fn sample<R: Rng>(&self, r: &mut R) -> f64 {
-        r.gen_range(self.min, self.max + 1.0)
+        r.gen_range(self.min, self.max)
     }
 }
 

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -92,7 +92,9 @@ impl Distribution<f64> for Uniform {
     /// # }
     /// ```
     fn sample<R: Rng>(&self, r: &mut R) -> f64 {
-        r.gen_range(self.min, self.max)
+        use rand::{Closed01, Rand};
+        let Closed01(rand01) =  Closed01::<f64>::rand(r);
+        self.min + rand01 * (self.max - self.min)
     }
 }
 

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -469,8 +469,9 @@ mod test {
     fn test_in_range() {
         use super::Distribution;
 
-        use rand::StdRng;
-        let mut r = StdRng::new().unwrap();
+        use rand::{StdRng, SeedableRng};
+        let seed: &[_] = &[1, 2, 3, 4, 5];
+        let mut r: StdRng = SeedableRng::from_seed(seed);
 
         let min = -4.2;
         let max = 0.42;


### PR DESCRIPTION
Hi and thanks for the library!

### Problem

I think there's a bug in the implementation of the continuous uniform distribution. According to the documentation, it should return values in the range `[min, max]`, i.e. `min` ≤ random value ≤ `max`.

Unfortunately, the current implementation generates values in the range `[min, max + 1)`, i.e. `min` ≤ random value < `max + 1`.

I think it might be a copy-paste bug 'inherited' from the discrete uniform distribution, where you really need to add 1 to the upper bound.

### Solution

This PR is a __partial__ fix for this bug: It changes the range of the continuous uniform distribution to `[min, max)`, i.e. `min` ≤ random value < `max`. I don't have a quick fix to include the upper bound, but I think it's important to at least fix the `+ 1.0` issue. As of `0.7.0`, you cannot really sample values between 0 and 1 without resorting to wild workarounds.

### References
* [MathNET implementation](https://github.com/mathnet/mathnet-numerics/blob/36a46bd7fcd3dc273fbd147bf6f27dabfdd0d586/src/Numerics/Distributions/ContinuousUniform.cs#L284-L287)
* [discrete uniform distribution in `statrs`](https://github.com/boxtown/statrs/blob/36a99a98880d16cbbab2c626a1ce18a4d13e84c1/src/distribution/discrete_uniform.rs#L94-L96)
* [`rand::Rng` trait](https://doc.rust-lang.org/rand/rand/trait.Rng.html#method.gen_range), which says that `gen_range()` does not include the upper bound