### PR TITLE
Add entropy of a categorical distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ HEAD
  - implemented infinite sequence generator for sawtooth sequence
  - deprecate old non-infinite iterators in favor of new infinite iterators with `take`
  - Implemented `Pareto` distribution
+ - Implemented `Entropy` trait for the `Categorical` distribution
 
 v0.8.0
  - `cdf(x)`, `pdf(x)` and `pmf(x)` now return the correct value instead of panicking when `x` is outside the range of values that the distribution can attain.

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -267,9 +267,10 @@ impl Entropy<f64> for Categorical {
     /// # Formula
     ///
     /// ```ignore
-    /// - Σ_j ( p_j * ln(p_j) )
+    /// - sum(p_j * ln(p_j)) for j in 0..k-1
     /// ```
-    /// where `p_j` the `j`th probability mass
+    /// where `p_j` the `j`th probability mass and `k` is the number
+    /// of categories
     fn entropy(&self) -> f64 {
         -self.norm_pmf
              .iter()

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -211,7 +211,7 @@ impl Mean<f64> for Categorical {
     /// # Formula
     ///
     /// ```ignore
-    /// sum(j * p_j) for j in 0..k-1
+    /// sum(j * p_j) for j in {0, 1, ..., k - 1}
     /// ```
     ///
     /// where `p_j` is the `j`th probability mass and `k` is the number
@@ -230,7 +230,7 @@ impl Variance<f64> for Categorical {
     /// # Formula
     ///
     /// ```ignore
-    /// sum(p_j * (j - μ)^2) for j in 0..k-1
+    /// sum(p_j * (j - μ)^2) for j in {0, 1, ..., k - 1}
     /// ```
     ///
     /// where `p_j` is the `j`th probability mass, `k` is the number
@@ -251,7 +251,7 @@ impl Variance<f64> for Categorical {
     /// # Formula
     ///
     /// ```ignore
-    /// sqrt(sum(p_j * (j - μ)^2)) for j in 0..k-1
+    /// sqrt(sum(p_j * (j - μ)^2)) for j in {0, 1, ..., k - 1}
     /// ```
     ///
     /// where `p_j` is the `j`th probability mass, `k` is the number
@@ -267,7 +267,7 @@ impl Entropy<f64> for Categorical {
     /// # Formula
     ///
     /// ```ignore
-    /// - sum(p_j * ln(p_j)) for j in 0..k-1
+    /// -sum(p_j * ln(p_j)) for j in {0, 1, ..., k - 1}
     /// ```
     /// where `p_j` the `j`th probability mass and `k` is the number
     /// of categories

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -211,11 +211,12 @@ impl Mean<f64> for Categorical {
     /// # Formula
     ///
     /// ```ignore
-    /// sum(j * p_j) for j in {0, 1, ..., k - 1}
+    /// Σ(j * p_j)
     /// ```
     ///
-    /// where `p_j` is the `j`th probability mass and `k` is the number
-    /// of categories
+    /// where `p_j` is the `j`th probability mass,
+    /// `Σ` is the sum from `0` to `k - 1`,
+    /// and `k` is the number of categories
     fn mean(&self) -> f64 {
         self.norm_pmf.iter().enumerate().fold(
             0.0,
@@ -230,11 +231,12 @@ impl Variance<f64> for Categorical {
     /// # Formula
     ///
     /// ```ignore
-    /// sum(p_j * (j - μ)^2) for j in {0, 1, ..., k - 1}
+    /// Σ(p_j * (j - μ)^2)
     /// ```
     ///
-    /// where `p_j` is the `j`th probability mass, `k` is the number
-    /// of categories, and `μ` is the mean
+    /// where `p_j` is the `j`th probability mass, `μ` is the mean,
+    /// `Σ` is the sum from `0` to `k - 1`,
+    /// and `k` is the number of categories
     fn variance(&self) -> f64 {
         let mu = self.mean();
         self.norm_pmf.iter().enumerate().fold(
@@ -251,11 +253,12 @@ impl Variance<f64> for Categorical {
     /// # Formula
     ///
     /// ```ignore
-    /// sqrt(sum(p_j * (j - μ)^2)) for j in {0, 1, ..., k - 1}
+    /// sqrt(Σ(p_j * (j - μ)^2))
     /// ```
     ///
-    /// where `p_j` is the `j`th probability mass, `k` is the number
-    /// of categories, and `μ` is the mean
+    /// where `p_j` is the `j`th probability mass, `μ` is the mean,
+    /// `Σ` is the sum from `0` to `k - 1`,
+    /// and `k` is the number of categories
     fn std_dev(&self) -> f64 {
         self.variance().sqrt()
     }
@@ -267,10 +270,12 @@ impl Entropy<f64> for Categorical {
     /// # Formula
     ///
     /// ```ignore
-    /// -sum(p_j * ln(p_j)) for j in {0, 1, ..., k - 1}
+    /// -Σ(p_j * ln(p_j))
     /// ```
-    /// where `p_j` the `j`th probability mass and `k` is the number
-    /// of categories
+    ///
+    /// where `p_j` is the `j`th probability mass,
+    /// `Σ` is the sum from `0` to `k - 1`,
+    /// and `k` is the number of categories
     fn entropy(&self) -> f64 {
         -self.norm_pmf
              .iter()


### PR DESCRIPTION
Hello again! :grinning: 

So, about #49: The entropy formula for the categorical distribution is actually the _definition_ of the information entropy, see e.g. [Wikipedia](https://en.wikipedia.org/wiki/Entropy_(information_theory)#Definition).
If all categories have the same probability, the formula collapses to `ln(n)`, which is exactly the entropy of a discrete uniform distribution.

The only gotcha is to handle the cases when a category has zero probability. The naive implementation (used by Math.NET) would throw a `NaN` when multiplying `0.0` by `Inf`. So I added a `filter()` which maps `p * ln(p)` only on non-zero values. This case is also added to the unit test.

---

Close #49 
