### PR TITLE
Fix Clippy issues

### DIFF
--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -319,7 +319,7 @@ pub fn sample_unchecked<R: Rng>(r: &mut R, cdf: &[f64]) -> f64 {
         idx += 1;
         el = unsafe { cdf.get_unchecked(idx) };
     }
-    return idx as f64;
+    idx as f64
 }
 
 /// Computes the cdf from the given probability masses. Performs

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -304,10 +304,7 @@ impl<'a> Continuous<&'a [f64], f64> for Dirichlet {
     /// `Π` is the product from `1` to `K`, `Σ` is the sum from `1` to `K`,
     /// and `K` is the number of concentration parameters
     fn ln_pdf(&self, x: &[f64]) -> f64 {
-        assert!(
-            self.alpha.len() == x.len(),
-            format!("{}", StatsError::ContainersMustBeSameLength)
-        );
+        assert_eq!(self.alpha.len(), x.len(), "{}", StatsError::ContainersMustBeSameLength);
 
         let (term, sum_xi, sum_alpha) = x.iter()
                                          .enumerate()

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -14,7 +14,7 @@ pub fn is_valid_multinomial(arr: &[f64], incl_zero: bool) -> bool {
         }
         sum += el;
     }
-    if sum == 0.0 { false } else { true }
+    sum != 0.0
 }
 
 #[cfg(test)]

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -235,14 +235,8 @@ impl<'a> Discrete<&'a [u64], f64> for Multinomial {
     /// `x_i` is the `i`th `x` value, and `k` is the total number of
     /// probabilities
     fn pmf(&self, x: &[u64]) -> f64 {
-        assert!(
-            self.p.len() == x.len(),
-            format!("{}", StatsError::ContainersMustBeSameLength)
-        );
-        assert!(
-            x.iter().fold(0, |acc, x| acc + x) == self.n,
-            format!("{}", StatsError::ContainerExpectedSumVar("x", "n"))
-        );
+        assert_eq!(self.p.len(), x.len(), "{}", StatsError::ContainersMustBeSameLength);
+        assert_eq!(x.iter().sum::<u64>(), self.n, "{}", StatsError::ContainerExpectedSumVar("x", "n"));
 
         let coeff = factorial::multinomial(self.n, x);
         coeff *
@@ -275,14 +269,8 @@ impl<'a> Discrete<&'a [u64], f64> for Multinomial {
     /// `x_i` is the `i`th `x` value, and `k` is the total number of
     /// probabilities
     fn ln_pmf(&self, x: &[u64]) -> f64 {
-        assert!(
-            self.p.len() == x.len(),
-            format!("{}", StatsError::ContainersMustBeSameLength)
-        );
-        assert!(
-            x.iter().fold(0, |acc, x| acc + x) == self.n,
-            format!("{}", StatsError::ContainerExpectedSumVar("x", "n"))
-        );
+        assert_eq!(self.p.len(), x.len(), "{}", StatsError::ContainersMustBeSameLength);
+        assert_eq!(x.iter().sum::<u64>(), self.n, "{}", StatsError::ContainerExpectedSumVar("x", "n"));
 
         let coeff = factorial::multinomial(self.n, x).ln();
         coeff +

--- a/src/distribution/ziggurat_tables.rs
+++ b/src/distribution/ziggurat_tables.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 //! Generated ziggurat tables borrowed from
-//! https://github.com/rust-lang-nursery/rand/blob/master/src/distributions/ziggurat_tables.rs
+//! `https://github.com/rust-lang-nursery/rand/blob/master/src/distributions/ziggurat_tables.rs`
 
 pub type ZigTable = &'static [f64; 257];
 pub const ZIG_NORM_R: f64 = 3.654152885361008796;

--- a/src/function/beta.rs
+++ b/src/function/beta.rs
@@ -94,7 +94,7 @@ pub fn beta_reg(a: f64, b: f64, x: f64) -> f64 {
     let mut h = d;
 
     for m in 1..141 {
-        let m = m as f64;
+        let m = f64::from(m);
         let m2 = m * 2.0;
         let mut aa = m * (b - m) * x / ((qam + m2) * (a + m2));
         d = 1.0 + aa * d;

--- a/src/function/factorial.rs
+++ b/src/function/factorial.rs
@@ -82,10 +82,7 @@ pub fn multinomial(n: u64, ni: &[u64]) -> f64 {
             (acc.0 + x, acc.1 - ln_factorial(x))
         },
     );
-    assert!(
-        sum == n,
-        format!("{}", StatsError::ContainerExpectedSumVar("ni", "n"))
-    );
+    assert_eq!(sum, n, "{}", StatsError::ContainerExpectedSumVar("ni", "n"));
     (0.5 + ret.exp()).floor()
 }
 

--- a/src/function/gamma.rs
+++ b/src/function/gamma.rs
@@ -248,7 +248,7 @@ pub fn gamma_lr(a: f64, x: f64) -> f64 {
         y += 1.0;
         z += 2.0;
         c += 1;
-        let yc = y * c as f64;
+        let yc = y * f64::from(c);
 
         let p = p2 * z - p3 * yc;
         let q = q2 * z - q3 * yc;

--- a/src/statistics/slice_statistics.rs
+++ b/src/statistics/slice_statistics.rs
@@ -23,7 +23,7 @@ impl OrderStatistics<f64> for [f64] {
     }
 
     fn quantile(&mut self, tau: f64) -> f64 {
-        if tau < 0.0 || tau > 1.0 || self.len() == 0 {
+        if tau < 0.0 || tau > 1.0 || self.is_empty() {
             return f64::NAN;
         }
 

--- a/src/statistics/slice_statistics.rs
+++ b/src/statistics/slice_statistics.rs
@@ -368,10 +368,7 @@ fn select_inplace(arr: &mut [f64], rank: usize) -> f64 {
 // insertion sort on small
 // containers and quick sorts for larger ones
 fn sort(primary: &mut [f64], secondary: &mut [usize]) {
-    assert!(
-        primary.len() == secondary.len(),
-        format!("{}", StatsError::ContainersMustBeSameLength)
-    );
+    assert_eq!(primary.len(), secondary.len(), "{}", StatsError::ContainersMustBeSameLength);
 
     let n = primary.len();
     if n <= 1 {
@@ -411,10 +408,7 @@ fn sort(primary: &mut [f64], secondary: &mut [usize]) {
 
 // quick sorts a primary slice and re-orders the secondary slice automatically
 fn quick_sort(primary: &mut [f64], secondary: &mut [usize], left: usize, right: usize) {
-    assert!(
-        primary.len() == secondary.len(),
-        format!("{}", StatsError::ContainersMustBeSameLength)
-    );
+    assert_eq!(primary.len(), secondary.len(), "{}", StatsError::ContainersMustBeSameLength);
 
     // shadow left and right for mutability in loop
     let mut left = left;
@@ -493,10 +487,7 @@ fn quick_sort(primary: &mut [f64], secondary: &mut [usize], left: usize, right: 
 // quick sorts a primary slice and re-orders the secondary slice automatically.
 // Sorts secondarily by the secondary slice on primary key duplicates
 fn quick_sort_all(primary: &mut [f64], secondary: &mut [usize], left: usize, right: usize) {
-    assert!(
-        primary.len() == secondary.len(),
-        format!("{}", StatsError::ContainersMustBeSameLength)
-    );
+    assert_eq!(primary.len(), secondary.len(), "{}", StatsError::ContainersMustBeSameLength);
 
     // shadow left and right for mutability in loop
     let mut left = left;


### PR DESCRIPTION
Ok, this is a very minor PR since it fixes the simplest issues reported by Clippy.

What changed:
* Remove unnecessary return statement in d7753c83e777845835d609337ed6bbc6fd2923d7
* Use `assert_eq!` macros where possible—much better assertion/unit test reporting bb3e583dcaf8b35dfdbc6d1fb63f2bee0475d1b2
* Use `is_empty` instead of length comparison to `0` 7175cbc120a5d5c58617a6f99f63be400509abc0
* Replace `if`-branching by a comparison expression 185a8149c4de05b044197e06e145a06984ef30ad
* Fix Markdown markup in a docstring c004b1f259e211f42ede8c9e7155690f133b7eb6
* Use explicit lossless conversion—see Clippy explanation [here](https://rust-lang-nursery.github.io/rust-clippy/master/index.html#cast_lossless) 1e11bd1daded1be4b55942be407bc61fcbbed462