### PR TITLE
Update dependency on rand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 #editor specific
 /.vscode/
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ name = "statrs"
 path = "src/lib.rs"
 
 [dependencies]
-rand = "0.5"
+rand = "0.6.3"

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -249,11 +249,12 @@ impl<'a> CheckedDiscrete<&'a [u64], f64> for Multinomial {
             return Err(StatsError::ContainerExpectedSumVar("x", "n"));
         }
         let coeff = factorial::multinomial(self.n, x);
-        let val = coeff * self
-            .p
-            .iter()
-            .zip(x.iter())
-            .fold(1.0, |acc, (pi, xi)| acc * pi.powf(*xi as f64));
+        let val = coeff
+            * self
+                .p
+                .iter()
+                .zip(x.iter())
+                .fold(1.0, |acc, (pi, xi)| acc * pi.powf(*xi as f64));
         Ok(val)
     }
 
@@ -284,12 +285,13 @@ impl<'a> CheckedDiscrete<&'a [u64], f64> for Multinomial {
             return Err(StatsError::ContainerExpectedSumVar("x", "n"));
         }
         let coeff = factorial::multinomial(self.n, x).ln();
-        let val = coeff + self
-            .p
-            .iter()
-            .zip(x.iter())
-            .map(|(pi, xi)| *xi as f64 * pi.ln())
-            .fold(0.0, |acc, x| acc + x);
+        let val = coeff
+            + self
+                .p
+                .iter()
+                .zip(x.iter())
+                .map(|(pi, xi)| *xi as f64 * pi.ln())
+                .fold(0.0, |acc, x| acc + x);
         Ok(val)
     }
 }

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -435,7 +435,8 @@ mod test {
 
     #[test]
     fn test_samples_in_range() {
-        use rand::{StdRng, SeedableRng};
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
         use rand::distributions::Distribution;
 
         let seed = [

--- a/src/statistics/iter_statistics.rs
+++ b/src/statistics/iter_statistics.rs
@@ -244,7 +244,8 @@ where
 #[cfg(test)]
 mod test {
     use std::f64::consts;
-    use rand::{SeedableRng, StdRng};
+    use rand::rngs::StdRng;
+    use rand::{SeedableRng};
     use rand::distributions::Distribution;
     use distribution::Normal;
     use statistics::Statistics;

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -16,7 +16,7 @@ pub fn load_data(path: &str) -> Vec<f64> {
     // if reading the data file fails, we want to panic immediately
 
     let path_prefix = "./data/".to_string();
-    let true_path = path_prefix + path.trim().trim_left_matches('/');
+    let true_path = path_prefix + path.trim().trim_start_matches('/');
 
     let f = File::open(true_path).unwrap();
     let mut reader = BufReader::new(f);


### PR DESCRIPTION
This pull requests updates `statrs`' dependency on the `rand` random number generation crate. I re-ran the tests and benchmarks to check everything works, fixed up a couple deprecation warnings (that didn't appear when just doing `cargo build`).

Resolves #92 