### PR TITLE
Prevent Chi mean and variance producing NaN for dof > 340

### DIFF
--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -362,6 +362,14 @@ mod tests {
     }
 
     #[test]
+    fn test_large_dof_mean_not_nan() {
+        for i in 1..1000 {
+            let mean = Chi::new(i as f64).unwrap().mean().unwrap();
+            assert!(!mean.is_nan(), "Chi mean for {} dof was {}", i, mean);
+        }
+    }
+
+    #[test]
     #[should_panic]
     fn test_mean_degen() {
         let mean = |x: Chi| x.mean().unwrap();


### PR DESCRIPTION
The issue is mostly explained in the commit messages. Happy to answer any questions though.