### PR TITLE
cargo: nalgebra 0.23.0 -> 0.24.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 
 [dependencies]
 rand = "0.7.3"
-nalgebra = "0.23.0"
+nalgebra = "0.24.1"
 approx = "0.4.0"
 num-traits = "0.2.14"
 


### PR DESCRIPTION
Was having trouble using this due to the outdated nalgebra dep.

Any chance a release can be cut following the merge of this PR?
