### PR TITLE
fix: remove second statrs::distribution::laplace

### DIFF
--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -68,7 +68,6 @@ mod uniform;
 mod weibull;
 mod ziggurat;
 mod ziggurat_tables;
-mod laplace;
 
 use crate::Result;
 


### PR DESCRIPTION
There is already a declaration of `mod laplace;` earlier in the list, leading to errors when compiling.