### PR TITLE
fix typo: statrs::distribution::Gamma sample_unchecked

### DIFF
--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -316,7 +316,7 @@ pub fn sample_unchecked<R: Rng + ?Sized>(rng: &mut R, shape: f64, rate: f64) -> 
         v *= v * v;
         x *= x;
         let u: f64 = rng.gen();
-        if u < 1.0 - 0.0331 * x * x || u.ln() < 0.5 * x + d * (1.0 - v - v.ln()) {
+        if u < 1.0 - 0.0331 * x * x || u.ln() < 0.5 * x + d * (1.0 - v + v.ln()) {
             return afix * d * v / rate;
         }
     }


### PR DESCRIPTION
I might find a mistake of sign in the random value generation function in `statrs::distribution::Gamma`.
Please refer to another implementation of "Marsaglia and Tsang’s Method", for example

https://gist.github.com/fasiha/f289c1d4b9c244a42abee54d1d6206ed

or

https://www.hongliangjie.com/2012/12/19/how-to-generate-gamma-random-variables/