### PR TITLE
Ci/separate bench from testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,19 +47,53 @@ jobs:
       - name: Build (lib only)
         run: cargo hack check --rust-version --locked
 
-  test:
+  build-unit:
     needs: [clippy, fmt, msrv]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
           os: [ubuntu-latest, macos-latest, windows-latest]
-
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+      - name: Build unit tests
+        run: cargo test --lib --bins --no-run
 
-      - name: Test default features
+  build-integration:
+    needs: [clippy, fmt, msrv]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build integration tests
+        run: cargo test --tests --no-run
+
+  build-benches:
+    needs: [clippy, fmt, msrv]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build benchmarks
+        run: cargo test --benches --no-run
+
+  run-tests:
+    needs: [build-unit, build-integration]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run all tests
         run: cargo test
 
   features:

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -26,3 +26,6 @@ pub const EULER_MASCHERONI: f64 =
 
 /// Targeted accuracy instantiated over `f64`
 pub const ACC: f64 = 10e-11;
+
+/// Constant representing erf_inv(0.5) = erfc_inv(0.5)
+pub const ERFC_HALF: f64 = 0.4769362762044698733814183536431305598089697490594706447038826959193;

--- a/src/distribution/levy.rs
+++ b/src/distribution/levy.rs
@@ -1,7 +1,7 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf::{erf, erfc, erfc_inv};
 
-use crate::statistics::*;
+use crate::{consts, statistics::*};
 use core::f64;
 
 /// Implements the [Levy](https://en.wikipedia.org/wiki/L%C3%A9vy_distribution) distribution.
@@ -273,7 +273,7 @@ impl Median<f64> for Levy {
     /// where `μ` is the mean, `c` is the dispersion and `erfc_inv` is
     /// the inverse of the complementary error function.
     fn median(&self) -> f64 {
-        self.mu + self.c * 0.5 * erfc_inv(0.5).powf(-2.0)
+        self.mu + self.c * 0.5 * consts::ERFC_HALF.powf(-2.0)
     }
 }
 


### PR DESCRIPTION
modified behavior of CI to allow benchmark builds to fail and continue onto running tests. Should have likely had this anyway.

Noticed in #331 when changing statrs behavior regarding implementations of upstream traits for `rand`