### PR TITLE
stabilize geometric inverse cdf and clean lint warnings

### DIFF
--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -153,6 +153,23 @@ impl DiscreteCDF<u64, f64> for Geometric {
             ((-self.p).ln_1p() * (x as f64)).exp()
         }
     }
+
+    /// Calculates the inverse cumulative distribution function (quantile) for the
+    /// geometric distribution using its closed-form expression. Keeps behavior
+    /// consistent across platforms without relying on bisection.
+    fn inverse_cdf(&self, p: f64) -> u64 {
+        assert!((0.0..=1.0).contains(&p), "p must be on [0,1]");
+        if p <= 0.0 || prec::ulps_eq!(self.p, 1.0) {
+            return 1;
+        }
+        if p >= 1.0 {
+            return u64::MAX;
+        }
+
+        // k = ceil(log(1 - p) / log(1 - self.p)), clamped to domain ≥ 1.
+        let k = ((-p).ln_1p() / (-self.p).ln_1p()).ceil().max(1.0);
+        if k.is_finite() { k as u64 } else { u64::MAX }
+    }
 }
 
 impl Min<u64> for Geometric {

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -536,6 +536,7 @@ mod tests {
         test_exact(1., 1, invcdf(0.));
         test_exact(1., 1, invcdf(1.));
         test_exact(0.2, 1, invcdf(0.2));
+        test_exact(0.2, u64::MAX, invcdf(1.));
         test_exact(0.004, 173, invcdf(0.5));
     }
 }

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -344,7 +344,6 @@ impl Continuous<f64, f64> for InverseGamma {
 mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
-    use crate::distribution::internal::testing_boiler;
 
     testing_boiler!(shape: f64, rate: f64; InverseGamma; InverseGammaError);
 

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -323,7 +323,6 @@ mod tests {
     use super::*;
     use crate::prec;
 
-    use crate::distribution::internal::testing_boiler;
 
     testing_boiler!(location: f64, scale: f64; Laplace; LaplaceError);
 

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -364,7 +364,6 @@ impl Continuous<f64, f64> for LogNormal {
 mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
-    use crate::distribution::internal::testing_boiler;
 
     testing_boiler!(location: f64, scale: f64; LogNormal; LogNormalError);
 

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -138,6 +138,8 @@ impl core::fmt::Display for MultivariateNormalError {
 #[cfg(feature = "std")]
 impl std::error::Error for MultivariateNormalError {}
 
+type NormalizedConstructorArguments<D> = (OVector<f64, D>, OMatrix<f64, D, D>, Cholesky<f64, D>);
+
 impl MultivariateNormal<Dyn> {
     /// Constructs a new multivariate normal distribution with a mean of `mean`
     /// and covariance matrix `cov`
@@ -181,7 +183,7 @@ fn normalize_constructor_arguments<D>(
     mean: OVector<f64, D>,
     covariance: Option<OMatrix<f64, D, D>>,
     cholesky: Option<Cholesky<f64, D>>,
-) -> Result<(OVector<f64, D>, OMatrix<f64, D, D>, Cholesky<f64, D>), MultivariateNormalError>
+) -> Result<NormalizedConstructorArguments<D>, MultivariateNormalError>
 where
     D: DimMin<D, Output = D>,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<D>

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -323,7 +323,6 @@ impl Discrete<u64, f64> for NegativeBinomial {
 mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
-    use crate::distribution::internal::testing_boiler;
 
     testing_boiler!(r: f64, p: f64; NegativeBinomial; NegativeBinomialError);
 

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -342,7 +342,6 @@ pub fn sample_unchecked<R: ::rand::Rng + ?Sized>(rng: &mut R, lambda: f64) -> f6
 mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
-    use crate::distribution::internal::testing_boiler;
     testing_boiler!(lambda: f64; Poisson; PoissonError);
 
     #[test]

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -438,7 +438,6 @@ fn sample_unchecked<R: ::rand::Rng + ?Sized>(rng: &mut R, min: f64, max: f64, mo
 mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
-    use crate::distribution::internal::testing_boiler;
 
     testing_boiler!(min: f64, max: f64, mode: f64; Triangular; TriangularError);
 

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -348,7 +348,6 @@ mod tests {
     use super::*;
     use crate::prec;
     use crate::distribution::internal::density_util;
-    use crate::distribution::internal::testing_boiler;
 
     testing_boiler!(min: f64, max: f64; Uniform; UniformError);
 

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -381,7 +381,6 @@ impl Continuous<f64, f64> for Weibull {
 mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
-    use crate::distribution::internal::testing_boiler;
 
     testing_boiler!(shape: f64, scale: f64; Weibull; WeibullError);
 

--- a/src/function/evaluate.rs
+++ b/src/function/evaluate.rs
@@ -11,10 +11,7 @@
 ///
 /// Returns 0 for a 0 length coefficient slice
 pub fn polynomial(z: f64, coeff: &[f64]) -> f64 {
-    coeff
-        .into_iter()
-        .rev()
-        .fold(0_f64, |acc, val| acc * z + val)
+    coeff.iter().rev().fold(0_f64, |acc, val| acc * z + val)
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
## Summary
- Stabilize `Geometric::inverse_cdf` with a closed-form implementation to avoid platform-dependent bisection drift (Windows/no_std failure).
- Remove unused `testing_boiler` imports that caused `-Dwarnings` failures in coverage/nightly.


## Testing
- `cargo fmt -- --check`
- `cargo clippy --all-targets` (remaining warnings only in kernel tests: `uninlined_format_args`, unchanged)
- (to run in CI) `cargo test --no-default-features -F rand --target x86_64-pc-windows-gnu` or `windows-latest` and `cargo +nightly llvm-cov --no-report nextest`