### PR TITLE
fix: restore missing normalization of Dirichlet samples

### DIFF
--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -209,7 +209,7 @@ where
                 sum += sample;
                 sample
             }),
-        )
+        ) / sum
     }
 }
 


### PR DESCRIPTION
This was broken by commit a239ebe25006c985115bd1d127804a42413111d4 (#253, cc @YeungOnion).

- Fixes #344.