### PR TITLE
fix: compute Multinomial pmf/ln_pmf in log space to avoid NaN for large n

### DIFF
--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -303,19 +303,7 @@ where
     /// `x_i` is the `i`th `x` value, and `k` is the total number of
     /// probabilities
     fn pmf(&self, x: &OVector<u64, D>) -> f64 {
-        if self.p.len() != x.len() {
-            panic!("Expected x and p to have equal lengths.");
-        }
-        if x.iter().sum::<u64>() != self.n {
-            return 0.0;
-        }
-        let coeff = factorial::multinomial(self.n, x.as_slice());
-        coeff
-            * self
-                .p
-                .iter()
-                .zip(x.iter())
-                .fold(1.0, |acc, (pi, xi)| acc * pi.powf(*xi as f64))
+        self.ln_pmf(x).exp()
     }
 
     /// Calculates the log probability mass function for the multinomial
@@ -343,14 +331,15 @@ where
         if x.iter().sum::<u64>() != self.n {
             return f64::NEG_INFINITY;
         }
-        let coeff = factorial::multinomial(self.n, x.as_slice()).ln();
+        let coeff = factorial::ln_factorial(self.n)
+            - x.iter().map(|&xi| factorial::ln_factorial(xi)).sum::<f64>();
 
         coeff
             + self
                 .p
                 .iter()
                 .zip(x.iter())
-                .map(|(pi, xi)| *xi as f64 * pi.ln())
+                .map(|(pi, xi)| if *xi > 0 { *xi as f64 * pi.ln() } else { 0.0 })
                 .fold(0.0, |acc, x| acc + x)
     }
 }
@@ -522,6 +511,19 @@ mod tests {
             1e-15,
             pmf(dvector![1, 1, 1, 7]),
         );
+    }
+
+    #[test]
+    fn test_pmf_large_n_no_overflow() {
+        // Regression for #370: for large n the multinomial coefficient overflows
+        // f64 (-> inf) while prod(p_i^x_i) underflows to 0, so the old
+        // coeff * prod implementation returned NaN and ln_pmf returned +inf.
+        let m = Multinomial::new(vec![0.5, 0.5], 2000).unwrap();
+        let x: OVector<u64, Dyn> = dvector![1000, 1000];
+        let p = m.pmf(&x);
+        assert!(p.is_finite());
+        prec::assert_abs_diff_eq!(p, 0.017839011145854373, epsilon = 1e-12);
+        prec::assert_abs_diff_eq!(m.ln_pmf(&x), -4.026367582410558, epsilon = 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
## What

`Multinomial::pmf` and `Multinomial::ln_pmf` now compute the distribution entirely in log space, so valid large-`n` inputs return finite values instead of `NaN`/`+inf`.

- `pmf` delegates to `self.ln_pmf(x).exp()` (the length/sum guards are preserved: `ln_pmf` still panics on a length mismatch and returns `NEG_INFINITY` when the counts don't sum to `n`, and `NEG_INFINITY.exp() == 0.0`).
- `ln_pmf` builds the multinomial coefficient directly with `factorial::ln_factorial` (`ln n! - Σ ln x_i!`) instead of `factorial::multinomial(...).ln()`.
- Zero-count categories are skipped in the probability sum so an allowed zero probability no longer produces `0 * ln(0) = NaN`.

## Why

`factorial::multinomial` returns the coefficient itself (it exponentiates the stable log value before returning), which overflows `f64` to `+inf` once the log exceeds ~709.78. For `n = 2000`:

- `pmf` computed `inf * prod(p_i^x_i)`, and since the probability product simultaneously underflows to `0.0`, the result was `inf * 0.0 = NaN`.
- `ln_pmf` computed `inf.ln() = +inf`.

Both are wrong for perfectly valid inputs; SciPy returns finite values for the same parameters. Fixes #370.

## Testing

Added `test_pmf_large_n_no_overflow` (n=2000, p=[0.5, 0.5], x=[1000, 1000]), which asserts the pmf is finite and matches the lgamma-computed reference values (pmf ≈ 0.0178390111, ln_pmf ≈ -4.0263675824). Verified it fails on the previous implementation (`assert!(p.is_finite())` panics) and passes after the fix. The existing `test_pmf` cases still pass under the log-space implementation.

```
$ CARGO_BUILD_JOBS=2 cargo test -p statrs multinomial
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 716 filtered out
```

`cargo clippy -p statrs --all-targets -- -D warnings` is clean; `cargo fmt --check` reports no diffs in the touched file (the only fmt diffs on this tree are pre-existing in `geometric.rs`).
