### PR TITLE
Update nalgebra to 0.35 and add opt-in wasm_js support

### DIFF
--- a/.github/workflows/autofix-ci.yml
+++ b/.github/workflows/autofix-ci.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 env:
-  rust_clippy: 1.87
+  rust_clippy: 1.89
 
 jobs:
   autofix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,11 +90,5 @@ jobs:
       - name: Check WebAssembly without a host RNG
         run: cargo check --target wasm32-unknown-unknown --no-default-features --features std,nalgebra,rand --lib
 
-      - name: Check WebAssembly with the JavaScript RNG backend
-        run: cargo check --target wasm32-unknown-unknown --all-features --lib
-
       - name: Check WASI without a host RNG
         run: cargo check --target wasm32-wasip1 --no-default-features --features std,nalgebra,rand --lib
-
-      - name: Check WASI with all features
-        run: cargo check --target wasm32-wasip1 --all-features --lib

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,3 +76,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Check all possible feature sets
         run: cargo hack check --feature-powerset --no-dev-deps
+
+  wasm:
+    needs: [clippy, fmt]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust stable with WebAssembly targets
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown, wasm32-wasip1
+
+      - name: Check WebAssembly without a host RNG
+        run: cargo check --target wasm32-unknown-unknown --no-default-features --features std,nalgebra,rand --lib
+
+      - name: Check WebAssembly with the JavaScript RNG backend
+        run: cargo check --target wasm32-unknown-unknown --all-features --lib
+
+      - name: Check WASI without a host RNG
+        run: cargo check --target wasm32-wasip1 --no-default-features --features std,nalgebra,rand --lib
+
+      - name: Check WASI with all features
+        run: cargo check --target wasm32-wasip1 --all-features --lib

--- a/Cargo.lock.MSRV
+++ b/Cargo.lock.MSRV
@@ -76,7 +76,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -239,116 +239,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
+ "rand_core",
+ "wasm-bindgen",
 ]
-
-[[package]]
-name = "glam"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
-
-[[package]]
-name = "glam"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
-
-[[package]]
-name = "glam"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
-
-[[package]]
-name = "glam"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
-
-[[package]]
-name = "glam"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
-
-[[package]]
-name = "glam"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
-
-[[package]]
-name = "glam"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
-
-[[package]]
-name = "glam"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
-
-[[package]]
-name = "glam"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
-
-[[package]]
-name = "glam"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
-
-[[package]]
-name = "glam"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
-
-[[package]]
-name = "glam"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
-
-[[package]]
-name = "glam"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
-
-[[package]]
-name = "glam"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
-
-[[package]]
-name = "glam"
-version = "0.29.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
 
 [[package]]
 name = "glam"
@@ -367,6 +268,12 @@ name = "glam"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 
 [[package]]
 name = "half"
@@ -429,12 +336,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,36 +353,21 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nalgebra"
-version = "0.34.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
 dependencies = [
  "approx",
- "glam 0.14.0",
- "glam 0.15.2",
- "glam 0.16.0",
- "glam 0.17.3",
- "glam 0.18.0",
- "glam 0.19.0",
- "glam 0.20.5",
- "glam 0.21.3",
- "glam 0.22.0",
- "glam 0.23.0",
- "glam 0.24.2",
- "glam 0.25.0",
- "glam 0.27.0",
- "glam 0.28.0",
- "glam 0.29.3",
  "glam 0.30.10",
  "glam 0.31.1",
  "glam 0.32.1",
+ "glam 0.33.2",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.9.5",
- "rand_distr",
+ "rand",
  "simba",
  "typenum",
 ]
@@ -543,7 +429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -557,12 +442,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -599,15 +478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,25 +497,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
 
 [[package]]
 name = "rand"
@@ -654,27 +508,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
+ "rand_core",
 ]
 
 [[package]]
@@ -682,16 +517,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_distr"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
-dependencies = [
- "num-traits",
- "rand 0.9.5",
-]
 
 [[package]]
 name = "rawpointer"
@@ -756,9 +581,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
 dependencies = [
  "bytemuck",
 ]
@@ -817,14 +642,13 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
 dependencies = [
  "approx",
  "num-complex",
  "num-traits",
- "paste",
  "wide",
 ]
 
@@ -841,9 +665,10 @@ dependencies = [
  "anyhow",
  "approx",
  "criterion",
+ "getrandom",
  "nalgebra",
  "num-traits",
- "rand 0.10.2",
+ "rand",
 ]
 
 [[package]]
@@ -887,15 +712,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
 ]
 
 [[package]]
@@ -955,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -986,12 +802,6 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock.MSRV
+++ b/Cargo.lock.MSRV
@@ -244,11 +244,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
- "rand_core",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock.MSRV
+++ b/Cargo.lock.MSRV
@@ -665,7 +665,6 @@ dependencies = [
  "anyhow",
  "approx",
  "criterion",
- "getrandom",
  "nalgebra",
  "num-traits",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 include = ["CHANGELOG.md", "LICENSE.md", "src/", "tests/"]
 
 # When changing MSRV: Also update the README
-rust-version = "1.87.0"
+rust-version = "1.89.0"
 
 [lib]
 name = "statrs"
@@ -29,7 +29,8 @@ default = ["std", "nalgebra", "rand"]
 std = ["nalgebra?/std", "rand?/std"]
 # at the moment, all nalgebra features needs std
 nalgebra = ["dep:nalgebra", "std"]
-rand = ["dep:rand", "nalgebra?/rand", "rand?/std_rng"]
+rand = ["dep:rand", "nalgebra?/rand-no-std", "rand?/std_rng"]
+wasm_js = ["rand", "rand/thread_rng", "dep:getrandom", "getrandom/wasm_js"]
 
 [dependencies]
 approx = "0.5.0"
@@ -41,7 +42,12 @@ optional = true
 default-features = false
 
 [dependencies.nalgebra]
-version = "0.34"
+version = "0.35"
+optional = true
+default-features = false
+
+[dependencies.getrandom]
+version = "0.4"
 optional = true
 default-features = false
 
@@ -50,7 +56,7 @@ criterion = "0.5"
 anyhow = "1.0"
 
 [dev-dependencies.nalgebra]
-version = "0.34"
+version = "0.35"
 default-features = false
 features = ["macros"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ std = ["nalgebra?/std", "rand?/std"]
 # at the moment, all nalgebra features needs std
 nalgebra = ["dep:nalgebra", "std"]
 rand = ["dep:rand", "nalgebra?/rand-no-std", "rand?/std_rng"]
-wasm_js = ["rand", "rand/thread_rng", "dep:getrandom", "getrandom/wasm_js"]
 
 [dependencies]
 approx = "0.5.0"
@@ -43,11 +42,6 @@ default-features = false
 
 [dependencies.nalgebra]
 version = "0.35"
-optional = true
-default-features = false
-
-[dependencies.getrandom]
-version = "0.4"
 optional = true
 default-features = false
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ statrs = "*" # replace * by the latest version of the crate.
 
 For examples, view [the docs](https://docs.rs/statrs/*/statrs/).
 
+### WebAssembly randomness
+
+On `wasm32-unknown-unknown`, sampling works with an explicitly seeded random
+number generator without a host entropy source. Applications that need
+JavaScript entropy, for example for `rand::rng()`, can enable the `wasm_js`
+feature:
+
+```toml
+[dependencies]
+statrs = { version = "*", features = ["wasm_js"] }
+rand = "0.10"
+```
+
+Do not enable `wasm_js` for non-JavaScript WebAssembly targets.
+
 ### Running tests
 
 If you'd like to run all suggested tests, you'll need to download some data from
@@ -53,7 +68,7 @@ If you'd like to modify where the data is downloaded, you can use the environmen
 
 ## Minimum supported Rust version (MSRV)
 
-This crate requires a Rust version of 1.87.0 or higher. Increases in MSRV will be considered a semver non-breaking API change and require a version increase (PATCH until 1.0.0, MINOR after 1.0.0).
+This crate requires a Rust version of 1.89.0 or higher. Increases in MSRV will be considered a semver non-breaking API change and require a version increase (PATCH until 1.0.0, MINOR after 1.0.0).
 
 ## Precision
 Floating-point numbers cannot always represent decimal values exactly, which can introduce small (and in some cases catastrophically large) errors in computations.

--- a/README.md
+++ b/README.md
@@ -42,16 +42,17 @@ For examples, view [the docs](https://docs.rs/statrs/*/statrs/).
 
 On `wasm32-unknown-unknown`, sampling works with an explicitly seeded random
 number generator without a host entropy source. Applications that need
-JavaScript entropy, for example for `rand::rng()`, can enable the `wasm_js`
-feature:
+JavaScript entropy, for example for `rand::rng()`, must select the `getrandom`
+backend themselves:
 
 ```toml
 [dependencies]
-statrs = { version = "*", features = ["wasm_js"] }
+statrs = "*"
 rand = "0.10"
+getrandom = { version = "0.4", features = ["wasm_js"] }
 ```
 
-Do not enable `wasm_js` for non-JavaScript WebAssembly targets.
+`statrs` does not select a randomness backend for downstream applications.
 
 ### Running tests
 

--- a/benches/order_statistics.rs
+++ b/benches/order_statistics.rs
@@ -6,7 +6,9 @@ use statrs::statistics::*;
 
 fn bench_order_statistic(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
-    let k = black_box(rng.random_range(..=usize::MAX));
+    let data: Vec<_> = (0..100).map(|x| x as f64).collect();
+    let order = black_box(rng.random_range(1..=data.len()));
+    let percentile = black_box(rng.random_range(0..=100));
     let tau = black_box(rng.random_range(0.0..1.0));
     let mut to_random_owned = |data: &[f64]| -> Data<Vec<f64>> {
         let mut owned = data.to_vec();
@@ -14,11 +16,10 @@ fn bench_order_statistic(c: &mut Criterion) {
         Data::new(owned)
     };
     let mut group = c.benchmark_group("order statistic");
-    let data: Vec<_> = (0..100).map(|x| x as f64).collect();
     group.bench_function("order_statistic", |b| {
         b.iter_batched(
             || to_random_owned(&data),
-            |mut data| data.order_statistic(k),
+            |mut data| data.order_statistic(order),
             BatchSize::SmallInput,
         )
     });
@@ -39,7 +40,7 @@ fn bench_order_statistic(c: &mut Criterion) {
     group.bench_function("percentile", |b| {
         b.iter_batched(
             || to_random_owned(&data),
-            |mut data| data.percentile(k),
+            |mut data| data.percentile(percentile),
             BatchSize::SmallInput,
         )
     });

--- a/benches/order_statistics.rs
+++ b/benches/order_statistics.rs
@@ -1,18 +1,18 @@
 extern crate statrs;
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use rand::prelude::*;
+use rand::rngs::StdRng;
 use statrs::statistics::*;
 
 fn bench_order_statistic(c: &mut Criterion) {
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
-    let to_random_owned = |data: &[f64]| -> Data<Vec<f64>> {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(42);
+    let k = black_box(rng.random_range(..=usize::MAX));
+    let tau = black_box(rng.random_range(0.0..1.0));
+    let mut to_random_owned = |data: &[f64]| -> Data<Vec<f64>> {
         let mut owned = data.to_vec();
         owned.shuffle(&mut rng);
         Data::new(owned)
     };
-    let k = black_box(rng.random_range(..=usize::MAX));
-    let tau = black_box(rng.random_range(0.0..1.0));
     let mut group = c.benchmark_group("order statistic");
     let data: Vec<_> = (0..100).map(|x| x as f64).collect();
     group.bench_function("order_statistic", |b| {

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -589,4 +589,18 @@ mod tests {
         let invcdf = |arg: f64| move |x: Geometric| x.inverse_cdf(arg);
         test_exact(1., 1, invcdf(2.));
     }
+
+    #[test]
+    #[should_panic(expected = "intermediate value overflowed f64")]
+    fn test_inverse_cdf_intermediate_overflow_panic() {
+        let distribution = Geometric::new(f64::from_bits(1)).unwrap();
+        distribution.inverse_cdf(0.5);
+    }
+
+    #[test]
+    #[should_panic(expected = "result exceeds u64::MAX")]
+    fn test_inverse_cdf_result_overflow_panic() {
+        let distribution = Geometric::new(1e-20).unwrap();
+        distribution.inverse_cdf(0.5);
+    }
 }


### PR DESCRIPTION
## Motivation

I encountered this while using `statrs` in a Leptos application targeting
`wasm32-unknown-unknown`.

Seeded sampling should not require a host entropy source, while browser
applications using APIs such as `rand::rng()` need an explicit JavaScript
entropy backend.

This PR now builds on the `rand 0.10` migration already present in `main` and
focuses on separating those two WebAssembly use cases.

## Changes

- Update `nalgebra` from 0.34 to 0.35.
- Use `nalgebra/rand-no-std` from the `rand` feature instead of enabling
  nalgebra's full `rand` feature bundle.
- Add the opt-in `wasm_js` feature, enabling:
  - `rand/thread_rng`
  - `getrandom/wasm_js`
- Add CI checks for:
  - `wasm32-unknown-unknown` with seeded RNG support
  - `wasm32-unknown-unknown` with `wasm_js`
  - `wasm32-wasip1`
- Document when applications should enable `wasm_js`.
- Fix the order statistics benchmark so it measures valid inputs.
- Cover the geometric inverse CDF overflow guards.
- Increase MSRV from 1.87 to 1.89, as required by `nalgebra 0.35`.

## Validation

- `cargo fmt -- --check`
- clippy on Rust 1.97 with warnings denied
- default, no-default-features plus `rand`, and all-features tests
- all 11 feature combinations
- `wasm32-unknown-unknown` and `wasm32-wasip1` checks
- MSRV 1.89 with the committed MSRV lockfile
- order statistics benchmark smoke test

## Acknowledgements

Thanks to @RobertJacobsonCDC for the earlier `rand 0.9` migration in #331 and
to @qkniep for the `rand 0.10` work in #374. Those contributions and the
follow-up changes now present in `main` helped shape the final, smaller scope of
this PR.
