### PR TITLE
chore: update branch refs from master to main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   coverage:
     strategy: # allows pinning additional nightly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CARGO_INCREMENTAL: 0

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ git clone https://github.com/statrs-dev/statrs
 Create a feature branch:
 
 ```sh
-git checkout -b <feature_branch> master
+git checkout -b <feature_branch> main
 ```
 
 Write your code and docs, then ensure it is formatted:


### PR DESCRIPTION
Follow-up to the default branch rename (master -> main): updates CI workflow triggers and the README contribution snippet to reference `main`.