### PR TITLE
Converge the default continuous inverse_cdf instead of a fixed 16 iterations

### DIFF
--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -513,4 +513,43 @@ mod tests {
         density_util::check_continuous_distribution(&create_ok(2), 0.0, 10.0);
         density_util::check_continuous_distribution(&create_ok(5), 0.0, 10.0);
     }
+
+    #[test]
+    fn test_inverse_cdf_reference() {
+        // Chi has no closed-form inverse_cdf, so it exercises the ContinuousCDF
+        // default. References are scipy.stats.chi.ppf, verified against mpmath
+        // (dps=60) to rel err < 4e-15; both tails are covered because the old
+        // fixed-iteration search collapsed there (e.g. k=1, p=1e-12 was off by ~2e7).
+        let cases: &[(u64, f64, f64)] = &[
+            (1, 1e-12, 1.253314137315499e-12),  (1, 1e-8, 1.2533141373155e-8),
+            (1, 1e-4, 0.000125331414059667),     (1, 1e-2, 0.012533469508069257),
+            (1, 0.5, 0.6744897501960812),        (1, 0.9999, 3.890591886413121),
+            (1, 0.99999999, 5.730728867384047),  (1, 0.999999999999, 7.130509892879273),
+            (2, 1e-12, 1.4142135623734486e-6),   (2, 1e-8, 0.00014142135659086288),
+            (2, 1e-4, 0.014142489196273646),     (2, 1e-2, 0.14177683769573532),
+            (2, 0.5, 1.1774100225154749),        (2, 0.9999, 4.29193205257872),
+            (2, 0.99999999, 6.069708516712743),  (2, 0.999999999999, 7.433847353543569),
+            (5, 1e-12, 0.007158661534693857),    (5, 1e-8, 0.04517451964256548),
+            (5, 1e-4, 0.28666596559134017),      (5, 1e-2, 0.7445119721859933),
+            (5, 0.5, 2.0860153861118875),        (5, 0.9999, 5.073936534787967),
+            (5, 0.99999999, 6.767169800763287),  (5, 0.999999999999, 8.077046646057179),
+        ];
+        for &(k, p, expected) in cases {
+            let q = Chi::new(k).unwrap().inverse_cdf(p);
+            let relerr = ((q - expected) / expected).abs();
+            assert!(relerr <= 1e-12, "Chi({k}).inverse_cdf({p}) = {q}, want {expected} (relerr {relerr:e})");
+        }
+    }
+
+    #[test]
+    fn test_inverse_cdf_round_trip() {
+        let ps = [1e-12, 1e-8, 1e-4, 1e-2, 0.25, 0.5, 0.75, 0.99, 1.0 - 1e-4, 1.0 - 1e-8, 1.0 - 1e-12];
+        for k in [1u64, 2, 3, 5, 10] {
+            let d = Chi::new(k).unwrap();
+            for &p in ps.iter() {
+                let back = d.cdf(d.inverse_cdf(p));
+                assert!((back - p).abs() <= 1e-9 * p, "Chi({k}) round-trip p={p}: cdf(inverse_cdf(p))={back}");
+            }
+        }
+    }
 }

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -472,4 +472,44 @@ mod tests {
         density_util::check_continuous_distribution(&create_ok(1.0, 0.5), 0.0, 100.0);
         density_util::check_continuous_distribution(&create_ok(9.0, 2.0), 0.0, 100.0);
     }
+
+    #[test]
+    fn test_inverse_cdf_reference() {
+        // InverseGamma has no closed-form inverse_cdf, so it exercises the
+        // ContinuousCDF default. References are scipy.stats.invgamma.ppf, verified
+        // against mpmath (dps=60) to rel err < 4e-15, spanning both tails up to
+        // p = 1 - 1e-12 (quantile ~6.4e23) where the old search lost all precision.
+        let cases: &[(f64, f64, f64, f64)] = &[
+            (1.0, 1.0, 1e-12, 0.03619120682527099),  (1.0, 1.0, 1e-6, 0.07238241365054197),
+            (1.0, 1.0, 1e-2, 0.21714724095162594),   (1.0, 1.0, 0.5, f64::consts::LOG2_E), // median = 1/ln 2
+
+            (1.0, 1.0, 0.9999, 9999.499991667344),   (1.0, 1.0, 0.99999999, 99999998.99752413),
+            (1.0, 1.0, 0.999999999999, 1000022122209.0044),
+            (0.5, 0.5, 1e-12, 0.019667954610891478), (0.5, 0.5, 1e-6, 0.04179182102150894),
+            (0.5, 0.5, 1e-2, 0.1507182493011397),    (0.5, 0.5, 0.5, 2.1981093383177344),
+            (0.5, 0.5, 0.9999, 63661976.90343876),   (0.5, 0.5, 0.99999999, 6366197659698592.0),
+            (0.5, 0.5, 0.999999999999, 6.366479395510921e23),
+            (3.0, 2.0, 1e-12, 0.05873305599299108),  (3.0, 2.0, 1e-6, 0.10455237678297954),
+            (3.0, 2.0, 1e-2, 0.23792679400084588),   (3.0, 2.0, 0.5, 0.7479262863802241),
+            (3.0, 2.0, 0.9999, 23.208303044174563),  (3.0, 2.0, 0.99999999, 510.37275811682616),
+            (3.0, 2.0, 0.999999999999, 11006.005315438017),
+        ];
+        for &(a, b, p, expected) in cases {
+            let q = InverseGamma::new(a, b).unwrap().inverse_cdf(p);
+            let relerr = ((q - expected) / expected).abs();
+            assert!(relerr <= 1e-12, "InverseGamma({a}, {b}).inverse_cdf({p}) = {q}, want {expected} (relerr {relerr:e})");
+        }
+    }
+
+    #[test]
+    fn test_inverse_cdf_round_trip() {
+        let ps = [1e-12, 1e-8, 1e-4, 1e-2, 0.25, 0.5, 0.75, 0.99, 1.0 - 1e-4, 1.0 - 1e-8, 1.0 - 1e-12];
+        for &(a, b) in &[(1.0, 1.0), (0.5, 0.5), (2.0, 1.0), (3.0, 2.0), (5.0, 3.0)] {
+            let d = InverseGamma::new(a, b).unwrap();
+            for &p in ps.iter() {
+                let back = d.cdf(d.inverse_cdf(p));
+                assert!((back - p).abs() <= 1e-9 * p, "InverseGamma({a}, {b}) round-trip p={p}: cdf(inverse_cdf(p))={back}");
+            }
+        }
+    }
 }

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -146,25 +146,55 @@ pub trait ContinuousCDF<K: Float, T: Float>: Min<K> + Max<K> {
             return self.max();
         };
         let two = K::one() + K::one();
-        let mut high = two;
-        let mut low = -high;
-        while self.cdf(low) > p {
-            low = low + low;
+
+        // Bracket the root, preferring the distribution's own domain bounds and
+        // only doubling outward from ±2 when a bound is not finite.
+        let mut low = self.min();
+        if !low.is_finite() {
+            low = -two;
+            while self.cdf(low) > p {
+                low = low + low;
+            }
         }
-        while self.cdf(high) < p {
-            high = high + high;
+        let mut high = self.max();
+        if !high.is_finite() {
+            high = two;
+            while self.cdf(high) < p {
+                high = high + high;
+            }
         }
-        let mut i = 16;
-        while i != 0 {
-            let mid = (high + low) / two;
-            if self.cdf(mid) >= p {
+
+        // In the upper half invert the survival function instead of the cdf:
+        // as `cdf` saturates to one it loses the resolution needed to place the
+        // quantile, whereas `sf` keeps that tail well conditioned.
+        let upper = p > T::one() / (T::one() + T::one());
+        let target = if upper { T::one() - p } else { p };
+
+        // Bisect until the bracket agrees to the crate's relative accuracy. A
+        // fixed iteration count cannot approach this when the bracket is wide or
+        // the quantile lies deep in a tail, where the search would otherwise
+        // return the bracket midpoint rather than the true value.
+        let accuracy = K::from(crate::prec::DEFAULT_RELATIVE_ACC).unwrap();
+        for _ in 0..100 {
+            let mid = low + (high - low) / two;
+            if mid <= low || mid >= high {
+                break;
+            }
+            let above = if upper {
+                self.sf(mid) <= target
+            } else {
+                self.cdf(mid) >= target
+            };
+            if above {
                 high = mid;
             } else {
                 low = mid;
             }
-            i -= 1;
+            if (high - low).abs() <= accuracy * low.abs().max(high.abs()) {
+                break;
+            }
         }
-        (high + low) / two
+        low + (high - low) / two
     }
 }
 
@@ -303,4 +333,49 @@ pub trait Discrete<K, T> {
     /// assert_abs_diff_eq!(n.ln_pmf(5), (0.24609375f64).ln(), epsilon = 1e-15);
     /// ```
     fn ln_pmf(&self, x: K) -> T;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ContinuousCDF, Max, Min};
+
+    // Standard logistic distribution, used to exercise the ContinuousCDF default
+    // inverse_cdf on an infinite (two-sided) support with a closed-form quantile.
+    struct Logistic;
+
+    impl Min<f64> for Logistic {
+        fn min(&self) -> f64 {
+            f64::NEG_INFINITY
+        }
+    }
+
+    impl Max<f64> for Logistic {
+        fn max(&self) -> f64 {
+            f64::INFINITY
+        }
+    }
+
+    impl ContinuousCDF<f64, f64> for Logistic {
+        fn cdf(&self, x: f64) -> f64 {
+            1.0 / (1.0 + (-x).exp())
+        }
+        fn sf(&self, x: f64) -> f64 {
+            1.0 / (1.0 + x.exp())
+        }
+    }
+
+    #[test]
+    fn test_default_inverse_cdf_infinite_support() {
+        let d = Logistic;
+        // Doubling out from ±2 on both sides, then cdf (lower) and sf (upper) search.
+        for &p in &[1e-10f64, 1e-4, 0.1, 0.3, 0.7, 0.9, 1.0 - 1e-4, 1.0 - 1e-10] {
+            let expected = (p / (1.0 - p)).ln();
+            let q = d.inverse_cdf(p);
+            let relerr = ((q - expected) / expected).abs();
+            assert!(
+                relerr <= 1e-11,
+                "logistic inverse_cdf({p}) = {q}, want {expected}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
The `ContinuousCDF::inverse_cdf` default runs a fixed 16-iteration bisection with no
convergence test, so it only ever narrows the initial bracket by 2^16 regardless of how
wide the bracket is or how small the quantile is. Every continuous distribution without a
closed-form quantile inherits this — currently `Chi` and `InverseGamma` — and the result
sits far from the crate's own `DEFAULT_RELATIVE_ACC` (1e-14):

- `Chi::new(1).inverse_cdf(1e-12)` returns `3.05e-5` instead of `1.25e-12`; in fact every
  `p <= ~1e-6` returns the same `3.05e-5` bracket floor. Even the median is only accurate
  to ~1e-5.
- `InverseGamma` shows the same ~1e-5 baseline error, growing into the tails.

This is the continuous mirror of the discrete side, which already converges via
`internal::integral_bisection_search`.

The fix replaces the fixed count with a bisection that runs until the bracket agrees to
`DEFAULT_RELATIVE_ACC` (capped at 100 iterations and by float resolution). Two smaller
changes make the tails accurate:

- Bracket from the distribution's own `min()`/`max()` when finite, only doubling out from
  ±2 when a bound is infinite. `Chi`/`InverseGamma` are supported on `[0, ∞)`, so the old
  `[-2, 2]` seed wasted the lower half.
- In the upper half, invert `sf` rather than `cdf`. As `cdf` saturates to one it can no
  longer place the quantile (many `x` map to a single `f64` cdf value); `sf` stays well
  conditioned. Distributions that don't override `sf` fall back to `1 - cdf`, so this is a
  no-op for them.

Across `p ∈ [1e-12, 1-1e-12]` the worst relative error for `Chi` and `InverseGamma` drops
from ~1e7 (and ~1e-5 at the median) to `<= 1.3e-14`. Reference quantiles in the new tests
come from scipy, cross-checked against mpmath at 60 digits; a round-trip test covers a
wider grid.

```rust
let q = Chi::new(1).unwrap().inverse_cdf(1e-12); // was 3.05e-5, want 1.25e-12
```
