### PR TITLE
feat(distribution): add non-panicking try_inverse_cdf

### DIFF
--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -193,6 +193,29 @@ impl ContinuousCDF<f64, f64> for Beta {
             beta::inv_beta_reg(self.shape_a, self.shape_b, x)
         }
     }
+
+    /// Calculates the inverse cumulative distribution function for the beta
+    /// distribution at `x`.
+    ///
+    /// # Returns an error instead of a panic
+    ///
+    /// If x is not in `[0, 1]`.
+    ///
+    /// # Formula
+    ///
+    /// ```text
+    /// I^{-1}_x(α, β)
+    /// ```
+    ///
+    /// where `α` is shapeA, `β` is shapeB, and `I_x` is the inverse of the
+    /// regularized lower incomplete beta function.
+    fn try_inverse_cdf(&self, x: f64) -> Result<f64, Box<dyn std::error::Error>> {
+        if !(0.0..=1.0).contains(&x) {
+            Err("x must be in [0, 1]".into())
+        } else {
+            Ok(beta::inv_beta_reg(self.shape_a, self.shape_b, x))
+        }
+    }
 }
 
 impl Min<f64> for Beta {

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -1,4 +1,4 @@
-use crate::distribution::{Continuous, ContinuousCDF};
+use crate::distribution::{Continuous, ContinuousCDF, InverseCdfError};
 use crate::function::{beta, gamma};
 use crate::prec;
 use crate::statistics::*;
@@ -209,9 +209,9 @@ impl ContinuousCDF<f64, f64> for Beta {
     ///
     /// where `α` is shapeA, `β` is shapeB, and `I_x` is the inverse of the
     /// regularized lower incomplete beta function.
-    fn try_inverse_cdf(&self, x: f64) -> Result<f64, Box<dyn std::error::Error>> {
+    fn try_inverse_cdf(&self, x: f64) -> Result<f64, InverseCdfError> {
         if !(0.0..=1.0).contains(&x) {
-            Err("x must be in [0, 1]".into())
+            Err(InverseCdfError::ArgumentOutOfRange)
         } else {
             Ok(beta::inv_beta_reg(self.shape_a, self.shape_b, x))
         }

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -166,6 +166,18 @@ pub trait ContinuousCDF<K: Float, T: Float>: Min<K> + Max<K> {
         }
         (high + low) / two
     }
+
+    /// Due to issues with rounding and floating-point accuracy the default
+    /// implementation may be ill-behaved.
+    /// Specialized inverse cdfs should be used whenever possible.
+    /// Performs a binary search on the domain of `cdf` to obtain an approximation
+    /// of `F^-1(p) := inf { x | F(x) >= p }`. Needless to say, performance may
+    /// may be lacking.
+    #[doc(alias = "quantile function")]
+    #[doc(alias = "quantile")]
+    fn try_inverse_cdf(&self, p: T) -> Result<K, Box<dyn std::error::Error>> {
+        Ok(self.inverse_cdf(p))
+    }
 }
 
 /// The `DiscreteCDF` trait is used to specify an interface for univariate

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -97,6 +97,25 @@ mod ziggurat;
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 mod ziggurat_tables;
 
+/// Represents the errors that can occur when computing [`ContinuousCDF::try_inverse_cdf`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[non_exhaustive]
+pub enum InverseCdfError {
+    /// The argument `p` is outside the closed interval `[0, 1]`.
+    ArgumentOutOfRange,
+}
+
+impl core::fmt::Display for InverseCdfError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            InverseCdfError::ArgumentOutOfRange => write!(f, "argument is outside [0, 1]"),
+        }
+    }
+}
+
+impl core::error::Error for InverseCdfError {}
+
 /// The `ContinuousCDF` trait is used to specify an interface for univariate
 /// distributions for which cdf float arguments are sensible.
 pub trait ContinuousCDF<K: Float, T: Float>: Min<K> + Max<K> {
@@ -175,7 +194,7 @@ pub trait ContinuousCDF<K: Float, T: Float>: Min<K> + Max<K> {
     /// may be lacking.
     #[doc(alias = "quantile function")]
     #[doc(alias = "quantile")]
-    fn try_inverse_cdf(&self, p: T) -> Result<K, Box<dyn std::error::Error>> {
+    fn try_inverse_cdf(&self, p: T) -> Result<K, InverseCdfError> {
         Ok(self.inverse_cdf(p))
     }
 }


### PR DESCRIPTION
start to expose fallible API for ContinuousCDF responding to #366

cherry-picked from #377
