### PR TITLE
refactor: Categorical now stores normalized values

### DIFF
--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -22,8 +22,8 @@ use core::f64;
 #[derive(Clone, PartialEq, Debug)]
 pub struct Categorical {
     norm_pmf: Vec<f64>,
-    cdf: Vec<f64>,
-    sf: Vec<f64>,
+    norm_cdf: Vec<f64>,
+    norm_sf: Vec<f64>,
 }
 
 /// Represents the errors that can occur when creating a [`Categorical`].
@@ -100,22 +100,25 @@ impl Categorical {
             return Err(CategoricalError::ProbMassSumZero);
         }
 
-        // extract un-normalized cdf
-        let cdf = prob_mass_to_cdf(prob_mass);
-        // extract un-normalized sf
-        let sf = cdf_to_sf(&cdf);
-        // extract normalized probability mass
-        let sum = cdf[cdf.len() - 1];
-        let mut norm_pmf = vec![0.0; prob_mass.len()];
-        norm_pmf
-            .iter_mut()
-            .zip(prob_mass.iter())
-            .for_each(|(np, pm)| *np = *pm / sum);
-        Ok(Categorical { norm_pmf, cdf, sf })
-    }
+        let mut cdf_sum = 0.0;
 
-    fn cdf_max(&self) -> f64 {
-        *self.cdf.last().unwrap()
+        let mut norm_cdf = Vec::with_capacity(prob_mass.len());
+        let mut norm_sf = Vec::with_capacity(prob_mass.len());
+        let mut norm_pmf = Vec::with_capacity(prob_mass.len());
+
+        for &prob in prob_mass {
+            cdf_sum += prob;
+
+            norm_cdf.push(cdf_sum / prob_sum);
+            norm_sf.push((prob_sum - cdf_sum) / prob_sum);
+            norm_pmf.push(prob / prob_sum);
+        }
+
+        Ok(Categorical {
+            norm_pmf,
+            norm_cdf,
+            norm_sf,
+        })
     }
 }
 
@@ -129,7 +132,8 @@ impl core::fmt::Display for Categorical {
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl ::rand::distr::Distribution<usize> for Categorical {
     fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        sample_unchecked(rng, &self.cdf)
+        let draw = ::rand::RngExt::random::<f64>(rng);
+        self.norm_cdf.iter().position(|val| *val >= draw).unwrap()
     }
 }
 
@@ -137,7 +141,7 @@ impl ::rand::distr::Distribution<usize> for Categorical {
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl ::rand::distr::Distribution<u64> for Categorical {
     fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> u64 {
-        sample_unchecked(rng, &self.cdf) as u64
+        <Self as ::rand::distr::Distribution<usize>>::sample(self, rng) as u64
     }
 }
 
@@ -145,7 +149,7 @@ impl ::rand::distr::Distribution<u64> for Categorical {
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl ::rand::distr::Distribution<f64> for Categorical {
     fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        sample_unchecked(rng, &self.cdf) as f64
+        <Self as ::rand::distr::Distribution<usize>>::sample(self, rng) as f64
     }
 }
 
@@ -161,11 +165,7 @@ impl DiscreteCDF<u64, f64> for Categorical {
     ///
     /// where `p_j` is the probability mass for the `j`th category
     fn cdf(&self, x: u64) -> f64 {
-        if x >= self.cdf.len() as u64 {
-            1.0
-        } else {
-            self.cdf.get(x as usize).unwrap() / self.cdf_max()
-        }
+        *self.norm_cdf.get(x as usize).unwrap_or(&1.0)
     }
 
     /// Calculates the survival function for the categorical distribution
@@ -177,11 +177,7 @@ impl DiscreteCDF<u64, f64> for Categorical {
     /// [ sum(p_j) from x..end ]
     /// ```
     fn sf(&self, x: u64) -> f64 {
-        if x >= self.sf.len() as u64 {
-            0.0
-        } else {
-            self.sf.get(x as usize).unwrap() / self.cdf_max()
-        }
+        *self.norm_sf.get(x as usize).unwrap_or(&0.0)
     }
 
     /// Calculates the inverse cumulative distribution function for the
@@ -205,8 +201,17 @@ impl DiscreteCDF<u64, f64> for Categorical {
         if x >= 1.0 || x <= 0.0 {
             panic!("x must be in [0, 1]")
         }
-        let denorm_prob = x * self.cdf_max();
-        binary_index(&self.cdf, denorm_prob) as u64
+
+        // `Vec::binary_search` will either return the index of a value equal to x
+        // or an index where x could be inserted into the sorted Vec.
+        // Both fit the description, so return either one.
+        match self
+            .norm_cdf
+            .binary_search_by(|v| v.partial_cmp(&x).unwrap())
+        {
+            Ok(idx) => idx as u64,
+            Err(idx) => idx as u64,
+        }
     }
 }
 
@@ -236,7 +241,7 @@ impl Max<u64> for Categorical {
     /// n
     /// ```
     fn max(&self) -> u64 {
-        self.cdf.len() as u64 - 1
+        self.norm_cdf.len() as u64 - 1
     }
 }
 
@@ -337,74 +342,6 @@ impl Discrete<u64, f64> for Categorical {
     fn ln_pmf(&self, x: u64) -> f64 {
         self.pmf(x).ln()
     }
-}
-
-/// Draws a sample from the categorical distribution described by `cdf`
-/// without doing any bounds checking
-#[cfg(feature = "rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-pub fn sample_unchecked<R: ::rand::Rng + ?Sized>(rng: &mut R, cdf: &[f64]) -> usize {
-    let draw = ::rand::RngExt::random::<f64>(rng) * cdf.last().unwrap();
-    cdf.iter().position(|val| *val >= draw).unwrap()
-}
-
-/// Computes the cdf from the given probability masses. Performs
-/// no parameter or bounds checking.
-pub fn prob_mass_to_cdf(prob_mass: &[f64]) -> Vec<f64> {
-    let mut cdf = Vec::with_capacity(prob_mass.len());
-    prob_mass.iter().fold(0.0, |s, p| {
-        let sum = s + p;
-        cdf.push(sum);
-        sum
-    });
-    cdf
-}
-
-/// Computes the sf from the given cumulative densities.
-/// Performs no parameter or bounds checking.
-pub fn cdf_to_sf(cdf: &[f64]) -> Vec<f64> {
-    let max = *cdf.last().unwrap();
-    cdf.iter().map(|x| max - x).collect()
-}
-
-// Returns the index of val if placed into the sorted search array.
-// If val is greater than all elements, it therefore would return
-// the length of the array (N). If val is less than all elements, it would
-// return 0. Otherwise val returns the index of the first element larger than
-// it within the search array.
-fn binary_index(search: &[f64], val: f64) -> usize {
-    use core::cmp;
-
-    let mut low = 0_isize;
-    let mut high = search.len() as isize - 1;
-    while low <= high {
-        let mid = low + ((high - low) / 2);
-        let el = *search.get(mid as usize).unwrap();
-        if el > val {
-            high = mid - 1;
-        } else if el < val {
-            low = mid.saturating_add(1);
-        } else {
-            return mid as usize;
-        }
-    }
-    cmp::min(search.len(), cmp::max(low, 0) as usize)
-}
-
-#[test]
-fn test_prob_mass_to_cdf() {
-    let arr = [0.0, 0.5, 0.5, 3.0, 1.1];
-    let res = prob_mass_to_cdf(&arr);
-    assert_eq!(res, [0.0, 0.5, 1.0, 4.0, 5.1]);
-}
-
-#[test]
-fn test_binary_index() {
-    let arr = [0.0, 3.0, 5.0, 9.0, 10.0];
-    assert_eq!(0, binary_index(&arr, -1.0));
-    assert_eq!(2, binary_index(&arr, 5.0));
-    assert_eq!(3, binary_index(&arr, 5.2));
-    assert_eq!(5, binary_index(&arr, 10.1));
 }
 
 #[rustfmt::skip]
@@ -543,10 +480,10 @@ mod tests {
     fn test_cdf_sf_mirror() {
         let mass = [4.0, 2.5, 2.5, 1.0];
         let cat = Categorical::new(&mass).unwrap();
-        assert_eq!(cat.cdf(0), 1.-cat.sf(0));
-        assert_eq!(cat.cdf(1), 1.-cat.sf(1));
-        assert_eq!(cat.cdf(2), 1.-cat.sf(2));
-        assert_eq!(cat.cdf(3), 1.-cat.sf(3));
+        assert_eq!(cat.cdf(0), 1. - cat.sf(0));
+        assert_eq!(cat.cdf(1), 1. - cat.sf(1));
+        assert_eq!(cat.cdf(2), 1. - cat.sf(2));
+        assert_eq!(cat.cdf(3), 1. - cat.sf(3));
     }
 
     #[test]

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -113,6 +113,21 @@ impl Categorical {
 
         Ok(Categorical { norm_pmf, norm_cdf })
     }
+
+    /// Returns the first index `i` such that `norm_cdf[i] >= x`.
+    ///
+    /// Used by both `inverse_cdf` and the `rand` sampler, which query
+    /// the same sorted `norm_cdf` data but have different domain
+    /// requirements on `x` (see call sites).
+    fn locate(&self, x: f64) -> u64 {
+        match self
+            .norm_cdf
+            .binary_search_by(|v| v.partial_cmp(&x).unwrap())
+        {
+            Ok(idx) => idx as u64,
+            Err(idx) => idx as u64,
+        }
+    }
 }
 
 impl core::fmt::Display for Categorical {
@@ -126,7 +141,7 @@ impl core::fmt::Display for Categorical {
 impl ::rand::distr::Distribution<usize> for Categorical {
     fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> usize {
         let draw = ::rand::RngExt::random::<f64>(rng);
-        self.norm_cdf.iter().position(|val| *val >= draw).unwrap()
+        self.locate(draw) as usize
     }
 }
 
@@ -183,16 +198,7 @@ impl DiscreteCDF<u64, f64> for Categorical {
             panic!("x must be in [0, 1]")
         }
 
-        // `Vec::binary_search` will either return the index of a value equal to x
-        // or an index where x could be inserted into the sorted Vec.
-        // Both fit the description, so return either one.
-        match self
-            .norm_cdf
-            .binary_search_by(|v| v.partial_cmp(&x).unwrap())
-        {
-            Ok(idx) => idx as u64,
-            Err(idx) => idx as u64,
-        }
+        self.locate(x)
     }
 }
 
@@ -481,6 +487,20 @@ mod tests {
             for x in 0..mass.len() as u64 + 1 {
                 crate::prec::assert_abs_diff_eq!(cat.cdf(x) + cat.sf(x), 1.0, epsilon = 1e-12);
             }
+        }
+    }
+
+    #[test]
+    fn test_locate_treats_zero_as_first_index() {
+        let cat = create_ok(&[4.0, 2.5, 2.5, 1.0]);
+        assert_eq!(cat.locate(0.0), 0);
+    }
+
+    #[test]
+    fn test_locate_matches_inverse_cdf() {
+        let cat = create_ok(&[4.0, 2.5, 2.5, 1.0]);
+        for &x in &[0.1, 0.2, 0.4, 0.5, 0.8, 0.95, 0.999] {
+            assert_eq!(cat.locate(x), cat.inverse_cdf(x));
         }
     }
 

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -23,7 +23,6 @@ use core::f64;
 pub struct Categorical {
     norm_pmf: Vec<f64>,
     norm_cdf: Vec<f64>,
-    norm_sf: Vec<f64>,
 }
 
 /// Represents the errors that can occur when creating a [`Categorical`].
@@ -103,22 +102,16 @@ impl Categorical {
         let mut cdf_sum = 0.0;
 
         let mut norm_cdf = Vec::with_capacity(prob_mass.len());
-        let mut norm_sf = Vec::with_capacity(prob_mass.len());
         let mut norm_pmf = Vec::with_capacity(prob_mass.len());
 
         for &prob in prob_mass {
             cdf_sum += prob;
 
             norm_cdf.push(cdf_sum / prob_sum);
-            norm_sf.push((prob_sum - cdf_sum) / prob_sum);
             norm_pmf.push(prob / prob_sum);
         }
 
-        Ok(Categorical {
-            norm_pmf,
-            norm_cdf,
-            norm_sf,
-        })
+        Ok(Categorical { norm_pmf, norm_cdf })
     }
 }
 
@@ -166,18 +159,6 @@ impl DiscreteCDF<u64, f64> for Categorical {
     /// where `p_j` is the probability mass for the `j`th category
     fn cdf(&self, x: u64) -> f64 {
         *self.norm_cdf.get(x as usize).unwrap_or(&1.0)
-    }
-
-    /// Calculates the survival function for the categorical distribution
-    /// at `x`
-    ///
-    /// # Formula
-    ///
-    /// ```text
-    /// [ sum(p_j) from x..end ]
-    /// ```
-    fn sf(&self, x: u64) -> f64 {
-        *self.norm_sf.get(x as usize).unwrap_or(&0.0)
     }
 
     /// Calculates the inverse cumulative distribution function for the
@@ -397,7 +378,7 @@ mod tests {
         test_exact(&[0.0, 1.0], 0.0, entropy);
         test_absolute(&[0.0, 1.0, 1.0], 2f64.ln(), 1e-15, entropy);
         test_absolute(&[1.0, 1.0, 1.0], 3f64.ln(), 1e-15, entropy);
-        test_absolute(&vec![1.0; 100], 100f64.ln(), 1e-14, entropy);
+        test_absolute(&[1.0; 100], 100f64.ln(), 1e-14, entropy);
         test_absolute(&[0.0, 0.25, 0.5, 0.25], 1.0397207708399179, 1e-15, entropy);
     }
 
@@ -484,6 +465,23 @@ mod tests {
         assert_eq!(cat.cdf(1), 1. - cat.sf(1));
         assert_eq!(cat.cdf(2), 1. - cat.sf(2));
         assert_eq!(cat.cdf(3), 1. - cat.sf(3));
+    }
+
+    #[test]
+    fn test_cdf_sf_sum_to_one() {
+        let masses: &[&[f64]] = &[
+            &[4.0, 2.5, 2.5, 1.0],
+            &[0.0, 3.0, 1.0, 1.0],
+            &[1.0, 1.0, 1.0, 1.0],
+            &[1.0; 20],
+        ];
+
+        for &mass in masses {
+            let cat = Categorical::new(mass).unwrap();
+            for x in 0..mass.len() as u64 + 1 {
+                crate::prec::assert_abs_diff_eq!(cat.cdf(x) + cat.sf(x), 1.0, epsilon = 1e-12);
+            }
+        }
     }
 
     #[test]

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -221,8 +221,8 @@ where
         + num_traits::FromPrimitive,
     super::Binomial: ::rand::distr::Distribution<T>,
 {
-    use nalgebra::Const;
     use ::rand::distr::Distribution;
+    use nalgebra::Const;
 
     let p = dist.p().as_slice();
     let mut res: OVector<T, D> = OVector::zeros_generic(dist.p.shape_generic().0, Const::<1>);

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -543,6 +543,56 @@ mod tests {
         assert_sync_send::<MultinomialError>();
     }
 
+    #[cfg(feature = "rand")]
+    #[test]
+    fn test_sample_sums_to_n_smallest_prob_not_last() {
+        use ::rand::distr::Distribution;
+        use ::rand::{rngs::StdRng, SeedableRng};
+
+        // The smallest probability (0.1) is at index 0, not the last
+        // position -- this is the exact shape that exposed a leftover-
+        // assignment bug in an earlier attempt at this algorithm, which
+        // assigned the remainder to the wrong output slot.
+        let dist = try_create(dvector![0.1, 0.6, 0.3], 37);
+        let mut rng = StdRng::seed_from_u64(20260719);
+        for _ in 0..10 {
+            let sample: OVector<u64, Dyn> = dist.sample(&mut rng);
+            assert_eq!(sample.iter().sum::<u64>(), 37);
+        }
+    }
+
+    #[cfg(feature = "rand")]
+    #[test]
+    fn test_sample_dominant_category_gets_almost_all_trials() {
+        use ::rand::distr::Distribution;
+        use ::rand::{rngs::StdRng, SeedableRng};
+
+        let dist = try_create(dvector![1e-9, 1e-9, 1.0 - 2e-9], 500);
+        let mut rng = StdRng::seed_from_u64(20260719);
+        let sample: OVector<u64, Dyn> = dist.sample(&mut rng);
+        assert_eq!(sample.iter().sum::<u64>(), 500);
+        assert!(
+            sample[2] >= 495,
+            "expected the overwhelmingly dominant category to get almost all trials, got {sample}"
+        );
+    }
+
+    #[cfg(feature = "rand")]
+    #[test]
+    fn test_sample_zero_weight_category_always_zero() {
+        use ::rand::distr::Distribution;
+        use ::rand::{rngs::StdRng, SeedableRng};
+
+        // p[1] == 0.0 exactly, and is not the last entry in the vector.
+        let dist = try_create(dvector![0.5, 0.0, 0.5], 41);
+        let mut rng = StdRng::seed_from_u64(20260719);
+        for _ in 0..10 {
+            let sample: OVector<u64, Dyn> = dist.sample(&mut rng);
+            assert_eq!(sample.iter().sum::<u64>(), 41);
+            assert_eq!(sample[1], 0);
+        }
+    }
+
     //     #[test]
     //     #[should_panic]
     //     fn test_pmf_x_wrong_length() {

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -168,6 +168,18 @@ where
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<D>,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<D>,
 {
+    /// # Numerical stability
+    ///
+    /// Each category's count is drawn from a [`Binomial`](crate::distribution::Binomial)
+    /// conditioned on the categories already sampled, using a probability
+    /// renormalized against the probability mass not yet assigned
+    /// (`p_i / remaining_mass`). As sampling proceeds and fewer categories
+    /// remain unprocessed, `remaining_mass` shrinks towards zero, which
+    /// can amplify floating-point error in that renormalized ratio. The
+    /// ratio is clamped to `[0.0, 1.0]` so this can never panic, but for
+    /// distributions with many categories, or a long tail of very small
+    /// probabilities, this may introduce a small bias in the
+    /// last-processed categories' counts.
     fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> OVector<u64, D> {
         sample_generic(self, rng)
     }
@@ -180,6 +192,18 @@ where
     D: Dim,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<D>,
 {
+    /// # Numerical stability
+    ///
+    /// Each category's count is drawn from a [`Binomial`](crate::distribution::Binomial)
+    /// conditioned on the categories already sampled, using a probability
+    /// renormalized against the probability mass not yet assigned
+    /// (`p_i / remaining_mass`). As sampling proceeds and fewer categories
+    /// remain unprocessed, `remaining_mass` shrinks towards zero, which
+    /// can amplify floating-point error in that renormalized ratio. The
+    /// ratio is clamped to `[0.0, 1.0]` so this can never panic, but for
+    /// distributions with many categories, or a long tail of very small
+    /// probabilities, this may introduce a small bias in the
+    /// last-processed categories' counts.
     fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> OVector<f64, D> {
         sample_generic(self, rng)
     }
@@ -191,27 +215,53 @@ where
     D: Dim,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<D>,
     R: ::rand::Rng + ?Sized,
-    T: ::num_traits::Num + ::nalgebra::Scalar + ::std::ops::AddAssign<T>,
+    T: ::nalgebra::Scalar
+        + num_traits::Zero
+        + num_traits::AsPrimitive<u64>
+        + num_traits::FromPrimitive,
+    super::Binomial: ::rand::distr::Distribution<T>,
 {
     use nalgebra::Const;
+    use ::rand::distr::Distribution;
 
-    let mut cdf_sum = 0.0;
-    let p_cdf: Vec<f64> = dist
-        .p()
-        .as_slice()
-        .iter()
-        .map(|p| {
-            cdf_sum += p;
-            cdf_sum
-        })
-        .collect();
+    let p = dist.p().as_slice();
+    let mut res: OVector<T, D> = OVector::zeros_generic(dist.p.shape_generic().0, Const::<1>);
 
-    let mut res = OVector::zeros_generic(dist.p.shape_generic().0, Const::<1>);
-    for _ in 0..dist.n {
-        let draw = ::rand::RngExt::random::<f64>(rng) * cdf_sum;
-        let i = p_cdf.iter().position(|val| *val >= draw).unwrap();
-        res[i] += T::one();
+    // Process categories from largest probability to smallest: this keeps
+    // `remaining_mass` shrinking predictably, and defers the
+    // hardest-to-renormalize (smallest-probability) category to the end,
+    // where it absorbs the leftover trial count directly instead of going
+    // through a division that would amplify floating-point error the most.
+    let mut sorted_inds: Vec<usize> = (0..p.len()).collect();
+    // `unwrap` is safe: `Multinomial::new` rejects NaN probabilities.
+    sorted_inds.sort_unstable_by(|&i, &j| p[j].partial_cmp(&p[i]).unwrap());
+    let (&skipped_ind, processed_inds) = sorted_inds
+        .split_last()
+        .expect("Multinomial::new requires at least 2 probabilities");
+
+    let mut remaining_mass = 1.0;
+    let mut samples_left = dist.n;
+    for &ind in processed_inds {
+        if samples_left == 0 {
+            break;
+        }
+        if p[ind] == 0.0 {
+            continue;
+        }
+
+        let p_binom = (p[ind] / remaining_mass).clamp(0.0, 1.0);
+        let drawn: T = super::Binomial::new(p_binom, samples_left)
+            .expect("p_binom is clamped to [0, 1]")
+            .sample(rng);
+        samples_left -= drawn.as_();
+        remaining_mass -= p[ind];
+        res[ind] = drawn;
     }
+    // Whatever trials remain belong to the one category left unprocessed
+    // above -- assigned by its actual index, not by output position.
+    res[skipped_ind] =
+        T::from_u64(samples_left).expect("samples_left is a valid u64 by construction");
+
     res
 }
 

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -195,10 +195,21 @@ where
 {
     use nalgebra::Const;
 
-    let p_cdf = super::categorical::prob_mass_to_cdf(dist.p().as_slice());
+    let mut cdf_sum = 0.0;
+    let p_cdf: Vec<f64> = dist
+        .p()
+        .as_slice()
+        .iter()
+        .map(|p| {
+            cdf_sum += p;
+            cdf_sum
+        })
+        .collect();
+
     let mut res = OVector::zeros_generic(dist.p.shape_generic().0, Const::<1>);
     for _ in 0..dist.n {
-        let i = super::categorical::sample_unchecked(rng, &p_cdf);
+        let draw = ::rand::RngExt::random::<f64>(rng) * cdf_sum;
+        let i = p_cdf.iter().position(|val| *val >= draw).unwrap();
         res[i] += T::one();
     }
     res


### PR DESCRIPTION
Cherry-pick of 37f8fdf (FreezyLemon) onto current main. The original commit predates the rand 0.9/0.10 migration and the `std`/`core` split, so it conflicted on:

- `::rand::distr::Distribution` (vs. old `rand::distributions::Distribution` alias)
- `RngExt::random` (vs. old `rng.gen`)

`Categorical` now stores `norm_cdf`/`norm_sf` directly instead of normalizing on every `cdf`/`sf`/`inverse_cdf` call, and `inverse_cdf` uses `binary_search_by` instead of a hand-rolled `binary_index`. The now-unused `sample_unchecked`/`prob_mass_to_cdf`/`cdf_to_sf`/`binary_index` helpers are removed; `Multinomial::sample`, which depended on `categorical::prob_mass_to_cdf`/`sample_unchecked`, now computes its cdf inline instead.

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo test --all-features` (192 passed)
- [x] `cargo clippy --all-features`