### PR TITLE
Document and test chi-squared boundary behavior

### DIFF
--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -358,6 +358,24 @@ mod tests {
     }
 
     #[test]
+    fn test_df_one_density_integrates_to_one() {
+        let distribution = create_ok(1.0);
+        let upper = 50.0f64;
+        let steps = 10_000;
+        let step = upper.sqrt() / steps as f64;
+        let integral = (0..steps)
+            .map(|i| {
+                let t = (i as f64 + 0.5) * step;
+                distribution.pdf(t * t) * 2.0 * t
+            })
+            .sum::<f64>()
+            * step;
+
+        assert!((integral - distribution.cdf(upper)).abs() < 1e-10);
+        assert!((integral - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
     fn test_continuous() {
         density_util::check_continuous_distribution(&create_ok(2.0), 0.0, 10.0);
         density_util::check_continuous_distribution(&create_ok(5.0), 0.0, 50.0);

--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -261,12 +261,13 @@ impl Median<f64> for ChiSquared {
 }
 
 impl Mode<Option<f64>> for ChiSquared {
-    /// Returns the mode of the chi-squared distribution
+    /// Returns the mode of the chi-squared distribution, or `None` if
+    /// `freedom` is less than `2`.
     ///
     /// # Formula
     ///
     /// ```text
-    /// k - 2
+    /// k - 2, where k >= 2
     /// ```
     ///
     /// where `k` is the degrees of freedom
@@ -278,6 +279,9 @@ impl Mode<Option<f64>> for ChiSquared {
 impl Continuous<f64, f64> for ChiSquared {
     /// Calculates the probability density function for the chi-squared
     /// distribution at `x`
+    ///
+    /// At `x = 0`, returns positive infinity for `freedom < 2`, `0.5` for
+    /// `freedom = 2`, and `0` for `freedom > 2`.
     ///
     /// # Formula
     ///
@@ -292,6 +296,9 @@ impl Continuous<f64, f64> for ChiSquared {
 
     /// Calculates the log probability density function for the chi-squared
     /// distribution at `x`
+    ///
+    /// At `x = 0`, returns positive infinity for `freedom < 2`, `ln(0.5)` for
+    /// `freedom = 2`, and negative infinity for `freedom > 2`.
     ///
     /// # Formula
     ///
@@ -321,9 +328,37 @@ mod tests {
     }
 
     #[test]
+    fn test_mode() {
+        for freedom in [0.5, 1.0, 1.5] {
+            assert_eq!(create_ok(freedom).mode(), None);
+        }
+
+        assert_eq!(create_ok(2.0).mode(), Some(0.0));
+        assert_eq!(create_ok(3.0).mode(), Some(1.0));
+        assert_eq!(create_ok(4.5).mode(), Some(2.5));
+    }
+
+    #[test]
+    fn test_density_at_zero() {
+        for freedom in [0.5, 1.0, 1.5] {
+            let distribution = create_ok(freedom);
+            assert_eq!(distribution.pdf(0.0), f64::INFINITY);
+            assert_eq!(distribution.ln_pdf(0.0), f64::INFINITY);
+        }
+
+        let distribution = create_ok(2.0);
+        assert_eq!(distribution.pdf(0.0), 0.5);
+        assert_eq!(distribution.ln_pdf(0.0), 0.5f64.ln());
+
+        for freedom in [2.5, 3.0, 10.0] {
+            let distribution = create_ok(freedom);
+            assert_eq!(distribution.pdf(0.0), 0.0);
+            assert_eq!(distribution.ln_pdf(0.0), f64::NEG_INFINITY);
+        }
+    }
+
+    #[test]
     fn test_continuous() {
-        // TODO: figure out why this test fails:
-        //check_continuous_distribution(&create_ok(1.0), 0.0, 10.0);
         density_util::check_continuous_distribution(&create_ok(2.0), 0.0, 10.0);
         density_util::check_continuous_distribution(&create_ok(5.0), 0.0, 50.0);
     }


### PR DESCRIPTION
## Motivation

#77 has been open since 2017 and identified missing coverage around the chi-squared mode and density at zero. The test suite also still contained a TODO for `df = 1`.

The implementation has evolved significantly since then. `ChiSquared` now delegates these calculations to `Gamma`, and the current density behavior is mathematically correct. Instead of porting the outdated implementation from #77, this PR documents and tests the current semantics and removes the stale TODO.

No runtime behavior is changed.

## Changes

- document that `mode()` returns `None` for `0 < df < 2`
- document the behavior of `pdf(0)` and `ln_pdf(0)`
- add boundary tests below, at, and above `df = 2`
- add a dedicated numerical integration test for `df = 1`
- remove the obsolete commented-out generic integration test

## Boundary behavior

| Degrees of freedom | `mode()` | `pdf(0)` | `ln_pdf(0)` |
|---|---:|---:|---:|
| `0 < df < 2` | `None` | `+∞` | `+∞` |
| `df = 2` | `Some(0)` | `0.5` | `ln(0.5)` |
| `df > 2` | `Some(df - 2)` | `0` | `-∞` |

For `0 < df < 2`, the density has an integrable singularity at zero. In particular, `pdf(0) = +∞`, but the total integral remains equal to `1`.

`None` for `mode()` in this range follows the existing `statrs` convention inherited from `Gamma`: the density does not have a finite maximum inside the positive support.

## SciPy comparison

The density behavior was compared against SciPy 1.17.0:

| `df` | SciPy `pdf(0)` | `statrs` `pdf(0)` | SciPy `logpdf(0)` | `statrs` `ln_pdf(0)` | SciPy `cdf(0)` | `statrs` `cdf(0)` |
|---:|---:|---:|---:|---:|---:|---:|
| `0.5` | `+∞` | `+∞` | `+∞` | `+∞` | `0` | `0` |
| `1.0` | `+∞` | `+∞` | `+∞` | `+∞` | `0` | `0` |
| `1.5` | `+∞` | `+∞` | `+∞` | `+∞` | `0` | `0` |
| `2.0` | `0.5` | `0.5` | `-0.6931471805599453` | `-0.6931471805599453` | `0` | `0` |
| `2.5` | `0` | `0` | `-∞` | `-∞` | `0` | `0` |
| `3.0` | `0` | `0` | `-∞` | `-∞` | `0` | `0` |
| `10.0` | `0` | `0` | `-∞` | `-∞` | `0` | `0` |

### Integration for `df = 1`

The generic integration helper uses the trapezoidal rule starting exactly at zero. It cannot handle `df = 1` because its first sample is `pdf(0) = +∞`.

The dedicated test uses the substitution `x = t²`, which removes the endpoint singularity, and integrates the transformed density over `x ∈ [0, 50]`.

Measured values:

```text
statrs integral:  0.99999999999846523
statrs cdf(50):   0.99999999999846256
difference:       2.66e-15
```
For comparison, SciPy's adaptive integration over [0, +∞) returns:
`1.000000000000631 ± 1.96e-11`