### PR TITLE
Add initial no_std support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,11 +59,24 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Test no_std
-        run: cargo test --no-default-features -F rand
-
       - name: Test default features
         run: cargo test
+
+  no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust stable with bare-metal target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: riscv32imac-unknown-none-elf
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check no_std core
+        run: cargo check --target riscv32imac-unknown-none-elf --no-default-features --lib
+
+      - name: Check no_std with rand
+        run: cargo check --target riscv32imac-unknown-none-elf --no-default-features --features rand --lib
 
   features:
     runs-on: ubuntu-latest

--- a/Cargo.lock.MSRV
+++ b/Cargo.lock.MSRV
@@ -350,6 +350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["rand", "std", "kde"]
 
 [features]
 default = ["std", "nalgebra", "rand"]
-std = ["nalgebra?/std", "rand?/std"]
+std = ["approx/std", "num-traits/std", "nalgebra?/std", "rand?/std"]
 # at the moment, all nalgebra features needs std
 nalgebra = ["dep:nalgebra", "std"]
 rand = ["dep:rand", "nalgebra?/rand-no-std", "rand?/std_rng"]
@@ -39,8 +39,8 @@ rand = ["dep:rand", "nalgebra?/rand-no-std", "rand?/std_rng"]
 kde = ["dep:kdtree", "nalgebra"]
 
 [dependencies]
-approx = "0.5.0"
-num-traits = "0.2.14"
+approx = { version = "0.5.0", default-features = false }
+num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
 thiserror = { version = "2.0", default-features = false }
 
 [dependencies.rand]

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -2,6 +2,8 @@ use crate::distribution::{Continuous, ContinuousCDF, InverseCdfError};
 use crate::function::{beta, gamma};
 use crate::prec;
 use crate::statistics::*;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Beta](https://en.wikipedia.org/wiki/Beta_distribution)
 /// distribution
@@ -44,8 +46,7 @@ impl core::fmt::Display for BetaError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BetaError {}
+impl core::error::Error for BetaError {}
 
 impl Beta {
     /// Constructs a new beta distribution with shapeA (α) of `shape_a`

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -3,6 +3,8 @@ use crate::function::{beta, factorial};
 use crate::prec;
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the
 /// [Binomial](https://en.wikipedia.org/wiki/Binomial_distribution)
@@ -42,8 +44,7 @@ impl core::fmt::Display for BinomialError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BinomialError {}
+impl core::error::Error for BinomialError {}
 
 impl Binomial {
     /// Constructs a new binomial distribution

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -53,8 +53,7 @@ impl core::fmt::Display for CategoricalError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for CategoricalError {}
+impl core::error::Error for CategoricalError {}
 
 impl Categorical {
     /// Constructs a new categorical distribution

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -1,6 +1,8 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Cauchy](https://en.wikipedia.org/wiki/Cauchy_distribution)
 /// distribution, also known as the Lorentz distribution.
@@ -42,8 +44,7 @@ impl core::fmt::Display for CauchyError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for CauchyError {}
+impl core::error::Error for CauchyError {}
 
 impl Cauchy {
     /// Constructs a new cauchy distribution with the given

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -3,6 +3,8 @@ use crate::function::gamma;
 use crate::statistics::*;
 use core::f64;
 use core::num::NonZeroU64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Chi](https://en.wikipedia.org/wiki/Chi_distribution)
 /// distribution
@@ -42,8 +44,7 @@ impl core::fmt::Display for ChiError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ChiError {}
+impl core::error::Error for ChiError {}
 
 impl Chi {
     /// Constructs a new chi distribution

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -33,8 +33,7 @@ impl core::fmt::Display for DiracError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DiracError {}
+impl core::error::Error for DiracError {}
 
 impl Dirac {
     /// Constructs a new dirac distribution function at value `v`.

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -54,8 +54,7 @@ impl core::fmt::Display for DirichletError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DirichletError {}
+impl core::error::Error for DirichletError {}
 
 impl Dirichlet<Dyn> {
     /// Constructs a new dirichlet distribution with the given

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -1,5 +1,7 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::statistics::*;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Discrete
 /// Uniform](https://en.wikipedia.org/wiki/Discrete_uniform_distribution)
@@ -38,8 +40,7 @@ impl core::fmt::Display for DiscreteUniformError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DiscreteUniformError {}
+impl core::error::Error for DiscreteUniformError {}
 
 impl DiscreteUniform {
     /// Constructs a new discrete uniform distribution with a minimum value

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -1,6 +1,8 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the
 /// [Exp](https://en.wikipedia.org/wiki/Exp_distribution)
@@ -40,8 +42,7 @@ impl core::fmt::Display for ExpError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ExpError {}
+impl core::error::Error for ExpError {}
 
 impl Exp {
     /// Constructs a new exponential distribution with a

--- a/src/distribution/fisher_snedecor.rs
+++ b/src/distribution/fisher_snedecor.rs
@@ -2,6 +2,8 @@ use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::beta;
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the
 /// [Fisher-Snedecor](https://en.wikipedia.org/wiki/F-distribution) distribution
@@ -49,8 +51,7 @@ impl core::fmt::Display for FisherSnedecorError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FisherSnedecorError {}
+impl core::error::Error for FisherSnedecorError {}
 
 impl FisherSnedecor {
     /// Constructs a new fisher-snedecor distribution with

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -2,6 +2,8 @@ use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::prec;
 use crate::statistics::*;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Gamma](https://en.wikipedia.org/wiki/Gamma_distribution)
 /// distribution
@@ -49,8 +51,7 @@ impl core::fmt::Display for GammaError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for GammaError {}
+impl core::error::Error for GammaError {}
 
 impl Gamma {
     /// Constructs a new gamma distribution with a shape (α)

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -2,6 +2,8 @@ use crate::distribution::{Discrete, DiscreteCDF};
 use crate::prec;
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 use num_traits::{One, Zero};
 
 #[cfg(feature = "rand")]
@@ -44,8 +46,7 @@ impl core::fmt::Display for GeometricError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for GeometricError {}
+impl core::error::Error for GeometricError {}
 
 impl Geometric {
     /// Constructs a new shifted geometric distribution with a probability

--- a/src/distribution/gumbel.rs
+++ b/src/distribution/gumbel.rs
@@ -3,6 +3,8 @@ use crate::consts::EULER_MASCHERONI;
 use crate::statistics::*;
 use core::f64;
 use core::f64::consts::PI;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Gumbel](https://en.wikipedia.org/wiki/Gumbel_distribution)
 /// distribution, also known as the type-I generalized extreme value distribution.
@@ -45,8 +47,7 @@ impl core::fmt::Display for GumbelError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for GumbelError {}
+impl core::error::Error for GumbelError {}
 
 impl Gumbel {
     /// Constructs a new Gumbel distribution with the given

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -3,6 +3,8 @@ use crate::function::factorial;
 use crate::statistics::*;
 use core::cmp;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the
 /// [Hypergeometric](http://en.wikipedia.org/wiki/Hypergeometric_distribution)
@@ -48,8 +50,7 @@ impl core::fmt::Display for HypergeometricError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for HypergeometricError {}
+impl core::error::Error for HypergeometricError {}
 
 impl Hypergeometric {
     /// Constructs a new hypergeometric distribution

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -3,6 +3,8 @@ use crate::function::gamma;
 use crate::prec;
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Inverse
 /// Gamma](https://en.wikipedia.org/wiki/Inverse-gamma_distribution)
@@ -50,8 +52,7 @@ impl core::fmt::Display for InverseGammaError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for InverseGammaError {}
+impl core::error::Error for InverseGammaError {}
 
 impl InverseGamma {
     /// Constructs a new inverse gamma distribution with a shape (α)

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -1,6 +1,8 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::{Distribution, Max, Median, Min, Mode};
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Laplace](https://en.wikipedia.org/wiki/Laplace_distribution)
 /// distribution.
@@ -42,8 +44,7 @@ impl core::fmt::Display for LaplaceError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LaplaceError {}
+impl core::error::Error for LaplaceError {}
 
 impl Laplace {
     /// Constructs a new laplace distribution with the given

--- a/src/distribution/levy.rs
+++ b/src/distribution/levy.rs
@@ -3,6 +3,8 @@ use crate::function::erf::{erf, erfc, erfc_inv};
 
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Levy](https://en.wikipedia.org/wiki/L%C3%A9vy_distribution) distribution.
 ///
@@ -41,8 +43,7 @@ impl core::fmt::Display for LevyError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LevyError {}
+impl core::error::Error for LevyError {}
 
 impl Levy {
     /// Constructs a new Levy distribution with a location (μ) and dispersion (c)

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -3,6 +3,8 @@ use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf;
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the
 /// [Log-normal](https://en.wikipedia.org/wiki/Log-normal_distribution)
@@ -46,8 +48,7 @@ impl core::fmt::Display for LogNormalError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LogNormalError {}
+impl core::error::Error for LogNormalError {}
 
 impl LogNormal {
     /// Constructs a new log-normal distribution with a location of `location`

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -59,8 +59,7 @@ impl core::fmt::Display for MultinomialError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MultinomialError {}
+impl core::error::Error for MultinomialError {}
 
 impl Multinomial<Dyn> {
     /// Constructs a new multinomial distribution with probabilities `p`

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -135,8 +135,7 @@ impl core::fmt::Display for MultivariateNormalError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MultivariateNormalError {}
+impl core::error::Error for MultivariateNormalError {}
 
 type NormalizedConstructorArguments<D> = (OVector<f64, D>, OMatrix<f64, D, D>, Cholesky<f64, D>);
 

--- a/src/distribution/multivariate_students_t.rs
+++ b/src/distribution/multivariate_students_t.rs
@@ -82,8 +82,7 @@ impl core::fmt::Display for MultivariateStudentError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MultivariateStudentError {}
+impl core::error::Error for MultivariateStudentError {}
 
 impl MultivariateStudent<Dyn> {
     /// Constructs a new multivariate students t distribution with a location of `location`,

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -2,6 +2,8 @@ use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{beta, gamma};
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the
 /// [negative binomial](http://en.wikipedia.org/wiki/Negative_binomial_distribution)
@@ -60,8 +62,7 @@ impl core::fmt::Display for NegativeBinomialError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for NegativeBinomialError {}
+impl core::error::Error for NegativeBinomialError {}
 
 impl NegativeBinomial {
     /// Constructs a new negative binomial distribution with parameters `r`

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -3,6 +3,8 @@ use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf;
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Normal](https://en.wikipedia.org/wiki/Normal_distribution)
 /// distribution
@@ -46,8 +48,7 @@ impl core::fmt::Display for NormalError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for NormalError {}
+impl core::error::Error for NormalError {}
 
 impl Normal {
     ///  Constructs a new normal distribution with a mean of `mean`

--- a/src/distribution/pareto.rs
+++ b/src/distribution/pareto.rs
@@ -1,6 +1,8 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Pareto](https://en.wikipedia.org/wiki/Pareto_distribution)
 /// distribution
@@ -43,8 +45,7 @@ impl core::fmt::Display for ParetoError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParetoError {}
+impl core::error::Error for ParetoError {}
 
 impl Pareto {
     /// Constructs a new Pareto distribution with scale `scale`, and `shape`

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -2,6 +2,8 @@ use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{factorial, gamma};
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution)
 /// distribution
@@ -39,8 +41,7 @@ impl core::fmt::Display for PoissonError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PoissonError {}
+impl core::error::Error for PoissonError {}
 
 impl Poisson {
     /// Constructs a new poisson distribution with a rate (λ)

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -2,6 +2,8 @@ use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::{beta, gamma};
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Student's
 /// T](https://en.wikipedia.org/wiki/Student%27s_t-distribution) distribution
@@ -51,8 +53,7 @@ impl core::fmt::Display for StudentsTError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for StudentsTError {}
+impl core::error::Error for StudentsTError {}
 
 impl StudentsT {
     /// Constructs a new student's t-distribution with location `location`,

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -1,6 +1,8 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the
 /// [Triangular](https://en.wikipedia.org/wiki/Triangular_distribution)
@@ -58,8 +60,7 @@ impl core::fmt::Display for TriangularError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TriangularError {}
+impl core::error::Error for TriangularError {}
 
 impl Triangular {
     /// Constructs a new triangular distribution with a minimum of `min`,

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -1,6 +1,8 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Continuous
 /// Uniform](https://en.wikipedia.org/wiki/Uniform_distribution_(continuous))
@@ -49,8 +51,7 @@ impl core::fmt::Display for UniformError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for UniformError {}
+impl core::error::Error for UniformError {}
 
 impl Uniform {
     /// Constructs a new uniform distribution with a min of `min` and a max

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -4,6 +4,8 @@ use crate::function::gamma;
 use crate::prec;
 use crate::statistics::*;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Implements the [Weibull](https://en.wikipedia.org/wiki/Weibull_distribution)
 /// distribution
@@ -48,8 +50,7 @@ impl core::fmt::Display for WeibullError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for WeibullError {}
+impl core::error::Error for WeibullError {}
 
 impl Weibull {
     /// Constructs a new weibull distribution with a shape (k) of `shape`

--- a/src/distribution/ziggurat.rs
+++ b/src/distribution/ziggurat.rs
@@ -1,4 +1,6 @@
 use super::ziggurat_tables;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 use rand::distr::Open01;
 use rand::{Rng, RngExt};
 

--- a/src/function/beta.rs
+++ b/src/function/beta.rs
@@ -6,6 +6,8 @@
 use crate::function::gamma;
 use crate::prec;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// sample case of module level precision
 const MODULE_EPS: f64 = 1e-15;
@@ -35,8 +37,7 @@ impl core::fmt::Display for BetaFuncError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BetaFuncError {}
+impl core::error::Error for BetaFuncError {}
 
 /// Computes the natural logarithm
 /// of the beta function

--- a/src/function/erf.rs
+++ b/src/function/erf.rs
@@ -3,6 +3,8 @@
 
 use crate::function::evaluate;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// `erf` calculates the error function at `x`.
 pub fn erf(x: f64) -> f64 {

--- a/src/function/exponential.rs
+++ b/src/function/exponential.rs
@@ -1,6 +1,8 @@
 //! Provides functions related to exponential calculations
 
 use crate::consts;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Computes the generalized Exponential Integral function
 /// where `x` is the argument and `n` is the integer power of the

--- a/src/function/factorial.rs
+++ b/src/function/factorial.rs
@@ -2,6 +2,8 @@
 //! coefficient, factorial, multinomial)
 
 use crate::function::gamma;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// The maximum factorial representable
 /// by a 64-bit floating point without

--- a/src/function/gamma.rs
+++ b/src/function/gamma.rs
@@ -4,6 +4,8 @@
 use crate::consts;
 use crate::prec;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Represents the errors that can occur when computing any of the incomplete
 /// gamma functions.
@@ -26,8 +28,7 @@ impl core::fmt::Display for GammaFuncError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for GammaFuncError {}
+impl core::error::Error for GammaFuncError {}
 
 /// Auxiliary variable when evaluating the `gamma_ln` function
 const GAMMA_R: f64 = 10.900511;

--- a/src/function/harmonic.rs
+++ b/src/function/harmonic.rs
@@ -4,6 +4,8 @@
 
 use crate::consts;
 use crate::function::gamma;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Computes the `t`-th harmonic number
 ///

--- a/src/function/kernel.rs
+++ b/src/function/kernel.rs
@@ -29,6 +29,8 @@
 //! ```
 
 use core::f64::consts::{FRAC_PI_2, PI};
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Common interface for kernel functions used in KDE and smoothing.
 pub trait Kernel {

--- a/src/function/logistic.rs
+++ b/src/function/logistic.rs
@@ -1,6 +1,9 @@
 //! Provides the [logistic](http://en.wikipedia.org/wiki/Logistic_function) and
 //! related functions
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 /// Computes the logistic function
 pub fn logistic(p: f64) -> f64 {
     1.0 / ((-p).exp() + 1.0)

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -2,6 +2,8 @@
 
 use crate::euclid::Modulus;
 use core::f64::consts;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 /// Generates a base 10 log spaced vector of the given length between the
 /// specified decade exponents (inclusive). Equivalent to MATLAB logspace
 ///

--- a/src/statistics/iter_statistics.rs
+++ b/src/statistics/iter_statistics.rs
@@ -1,6 +1,8 @@
 use crate::statistics::*;
 use core::borrow::Borrow;
 use core::f64;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 impl<T> Statistics<f64> for T
 where

--- a/src/statistics/online.rs
+++ b/src/statistics/online.rs
@@ -5,6 +5,9 @@
 //! [`OnlineMoments::push`] and can be read from repeatedly, or composed with
 //! [`Accumulate`] to share a single fold pass across several statistics.
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 /// Single-pass accumulator for central moments via Welford's online algorithm.
 ///
 /// `ORDER` controls which moments are tracked:

--- a/src/stats_tests/anderson_darling.rs
+++ b/src/stats_tests/anderson_darling.rs
@@ -17,8 +17,7 @@ impl core::fmt::Display for AndersonDarlingError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AndersonDarlingError {}
+impl core::error::Error for AndersonDarlingError {}
 
 pub fn anderson_darling<T: ContinuousCDF<f64, f64>>(
     f_obs: &[f64],

--- a/src/stats_tests/chisquare.rs
+++ b/src/stats_tests/chisquare.rs
@@ -36,8 +36,7 @@ impl core::fmt::Display for ChiSquareTestError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ChiSquareTestError {}
+impl core::error::Error for ChiSquareTestError {}
 
 /// Perform a Pearson's chi-square test
 ///

--- a/src/stats_tests/f_oneway.rs
+++ b/src/stats_tests/f_oneway.rs
@@ -39,7 +39,7 @@ impl core::fmt::Display for FOneWayTestError {
     }
 }
 
-impl std::error::Error for FOneWayTestError {}
+impl core::error::Error for FOneWayTestError {}
 
 /// Perform a one-way Analysis of Variance (ANOVA) F-test
 ///

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -108,8 +108,7 @@ impl core::fmt::Display for FishersExactTestError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FishersExactTestError {}
+impl core::error::Error for FishersExactTestError {}
 
 impl From<HypergeometricError> for FishersExactTestError {
     fn from(value: HypergeometricError) -> Self {

--- a/src/stats_tests/ks_test.rs
+++ b/src/stats_tests/ks_test.rs
@@ -50,7 +50,7 @@ impl core::fmt::Display for KSTestError {
     }
 }
 
-impl std::error::Error for KSTestError {}
+impl core::error::Error for KSTestError {}
 
 /// Represents the different methods that can be used when calculating the p-value for the
 /// one sample KS test.

--- a/src/stats_tests/mannwhitneyu.rs
+++ b/src/stats_tests/mannwhitneyu.rs
@@ -38,7 +38,7 @@ impl core::fmt::Display for MannWhitneyUError {
     }
 }
 
-impl std::error::Error for MannWhitneyUError {}
+impl core::error::Error for MannWhitneyUError {}
 
 /// Represents the different methods that can be used when calculating the p-value for the
 /// mannwhitneyu function

--- a/src/stats_tests/skewtest.rs
+++ b/src/stats_tests/skewtest.rs
@@ -31,8 +31,7 @@ impl core::fmt::Display for SkewTestError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SkewTestError {}
+impl core::error::Error for SkewTestError {}
 
 fn calc_root_b1(data: &[f64]) -> f64 {
     // Fisher's moment coefficient of skewness

--- a/src/stats_tests/ttest_onesample.rs
+++ b/src/stats_tests/ttest_onesample.rs
@@ -29,8 +29,7 @@ impl core::fmt::Display for TTestOneSampleError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TTestOneSampleError {}
+impl core::error::Error for TTestOneSampleError {}
 
 /// Perform a one sample t-test
 ///


### PR DESCRIPTION
## Motivation

`statrs` already declares `no_std` when the `std` feature is disabled, but the crate did not compile for a real bare-metal target.

The main blockers were:

- `approx` and `num-traits` enabling `std` through their default features
- floating-point methods unavailable through `core` on bare-metal targets
- error implementations depending on `std::error::Error`
- CI testing a hosted `no_std` configuration instead of a real bare-metal build

**It is not complete no_std feature. it is first step in the direction.** 