### PR TITLE
chore: release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1](https://github.com/statrs-dev/statrs/compare/v0.19.0...v0.19.1) - 2026-08-11
+
+### Added
+
+- let callers choose the binomial sampling algorithm
+
+### Fixed
+
+- Correct exact distribution boundaries
+- Beta::sf returning exactly 1.0 for tiny x
+- order the selection fast paths by total_cmp, not <=
+- replace hand-rolled quickselect with select_nth_unstable_by
+- address review on the BINV/BTPE sampler
+
+### Other
+
+- Alias f64 constants
+- Fix nightly f64 deprecation warnings
+- add a selection benchmark, and ordered fast paths it exposed
+- build the NaN order-statistic test under no_std
+- move binomial sampling into its own module
+- split the sampler's branch selection out of the RNG path
+- require std for the BTPE chi-square test
+- sample Binomial via BINV/BTPE instead of n Bernoulli trials
+- Bound the Newton iteration count and cover the quantile guards
+- Add safeguarded-Newton inverse_cdf for Chi and InverseGamma
+
 ## [0.19.0](https://github.com/statrs-dev/statrs/compare/v0.18.0...v0.19.0) - 2026-07-20
 
 ### Added

--- a/Cargo.lock.MSRV
+++ b/Cargo.lock.MSRV
@@ -697,7 +697,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "statrs"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statrs"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Michael Ma"]
 description = "Statistical computing library for Rust"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `statrs`: 0.19.0 -> 0.19.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.19.1](https://github.com/statrs-dev/statrs/compare/v0.19.0...v0.19.1) - 2026-08-11

### Added

- let callers choose the binomial sampling algorithm

### Fixed

- Correct exact distribution boundaries
- Beta::sf returning exactly 1.0 for tiny x
- order the selection fast paths by total_cmp, not <=
- replace hand-rolled quickselect with select_nth_unstable_by
- address review on the BINV/BTPE sampler

### Other

- Alias f64 constants
- Fix nightly f64 deprecation warnings
- add a selection benchmark, and ordered fast paths it exposed
- build the NaN order-statistic test under no_std
- move binomial sampling into its own module
- split the sampler's branch selection out of the RNG path
- require std for the BTPE chi-square test
- sample Binomial via BINV/BTPE instead of n Bernoulli trials
- Bound the Newton iteration count and cover the quantile guards
- Add safeguarded-Newton inverse_cdf for Chi and InverseGamma
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).