### PR TITLE
fix: restore exact distribution boundary handling

### DIFF
--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF, InverseCdfError};
 use crate::function::{beta, gamma};
-use crate::prec;
 use crate::statistics::*;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
@@ -143,7 +142,7 @@ impl ContinuousCDF<f64, f64> for Beta {
             0.0
         } else if x >= 1.0 {
             1.0
-        } else if prec::ulps_eq!(self.shape_a, 1.0) && prec::ulps_eq!(self.shape_b, 1.0) {
+        } else if self.shape_a == 1.0 && self.shape_b == 1.0 {
             x
         } else {
             beta::beta_reg(self.shape_a, self.shape_b, x)
@@ -165,14 +164,14 @@ impl ContinuousCDF<f64, f64> for Beta {
             1.0
         } else if x >= 1.0 {
             0.0
-        } else if prec::ulps_eq!(self.shape_a, 1.0) && prec::ulps_eq!(self.shape_b, 1.0) {
+        } else if self.shape_a == 1.0 && self.shape_b == 1.0 {
             1. - x
         } else if x < (self.shape_a + 1.0) / (self.shape_a + self.shape_b + 2.0) {
             // Below the continued fraction split point of `beta_reg`,
             // `beta_reg(b, a, 1 - x)` reduces to `1 - beta_reg(a, b, x)`;
             // computing the complement here instead avoids `1.0 - x`
             // rounding to 1.0 for tiny x (< ~1.1e-16), which would lose
-            // the lower tail entirely. See #432 
+            // the lower tail entirely. See #432
             1.0 - beta::beta_reg(self.shape_a, self.shape_b, x)
         } else {
             beta::beta_reg(self.shape_b, self.shape_a, 1.0 - x)
@@ -365,7 +364,7 @@ impl Continuous<f64, f64> for Beta {
     fn pdf(&self, x: f64) -> f64 {
         if !(0.0..=1.0).contains(&x) {
             0.0
-        } else if prec::ulps_eq!(self.shape_a, 1.0) && prec::ulps_eq!(self.shape_b, 1.0) {
+        } else if self.shape_a == 1.0 && self.shape_b == 1.0 {
             1.0
         } else if self.shape_a > 80.0 || self.shape_b > 80.0 {
             self.ln_pdf(x).exp()
@@ -391,23 +390,31 @@ impl Continuous<f64, f64> for Beta {
     fn ln_pdf(&self, x: f64) -> f64 {
         if !(0.0..=1.0).contains(&x) {
             f64::NEG_INFINITY
-        } else if prec::ulps_eq!(self.shape_a, 1.0) && prec::ulps_eq!(self.shape_b, 1.0) {
+        } else if self.shape_a == 1.0 && self.shape_b == 1.0 {
             0.0
         } else {
             let aa = gamma::ln_gamma(self.shape_a + self.shape_b)
                 - gamma::ln_gamma(self.shape_a)
                 - gamma::ln_gamma(self.shape_b);
-            let bb = if prec::ulps_eq!(self.shape_a, 1.0) && x == 0.0 {
-                0.0
-            } else if x == 0.0 {
-                f64::NEG_INFINITY
+            let bb = if x == 0.0 {
+                if self.shape_a < 1.0 {
+                    f64::INFINITY
+                } else if self.shape_a == 1.0 {
+                    0.0
+                } else {
+                    f64::NEG_INFINITY
+                }
             } else {
                 (self.shape_a - 1.0) * x.ln()
             };
-            let cc = if prec::ulps_eq!(self.shape_b, 1.0) && prec::ulps_eq!(x, 1.0) {
-                0.0
-            } else if prec::ulps_eq!(x, 1.0) {
-                f64::NEG_INFINITY
+            let cc = if x == 1.0 {
+                if self.shape_b < 1.0 {
+                    f64::INFINITY
+                } else if self.shape_b == 1.0 {
+                    0.0
+                } else {
+                    f64::NEG_INFINITY
+                }
             } else {
                 (self.shape_b - 1.0) * (1.0 - x).ln()
             };
@@ -572,6 +579,44 @@ mod tests {
         for ((a, b), x, expect) in test {
             test_relative(a, b, expect, f(x));
         }
+    }
+
+    #[test]
+    fn test_ln_pdf_near_upper_boundary() {
+        let x = 1.0 - 1e-9;
+        let test = [
+            ((2.0, 3.0), -38.961625081668685701),
+            ((0.05, 0.05), 16.002056822547670151),
+            ((5.0, 0.001), 13.796869938301040045),
+        ];
+        for ((a, b), expect) in test {
+            test_absolute(a, b, expect, 5e-14, |dist| dist.ln_pdf(x));
+        }
+    }
+
+    #[test]
+    fn test_density_at_boundaries() {
+        test_exact(0.5, 2.0, f64::INFINITY, |dist| dist.ln_pdf(0.0));
+        test_exact(2.0, 0.5, f64::INFINITY, |dist| dist.ln_pdf(1.0));
+        test_exact(2.0, 3.0, f64::NEG_INFINITY, |dist| dist.ln_pdf(0.0));
+        test_exact(2.0, 3.0, f64::NEG_INFINITY, |dist| dist.ln_pdf(1.0));
+    }
+
+    #[test]
+    fn test_near_uniform_shapes_are_not_uniform() {
+        let shape_a = 1.0 + 5e-10;
+        let x = 0.5_f64;
+        test_absolute(shape_a, 1.0, x.powf(shape_a), 5e-15, |dist| dist.cdf(x));
+        test_absolute(shape_a, 1.0, 1.0 - x.powf(shape_a), 5e-15, |dist| {
+            dist.sf(x)
+        });
+        test_absolute(
+            shape_a,
+            1.0,
+            shape_a * x.powf(shape_a - 1.0),
+            5e-15,
+            |dist| dist.pdf(x),
+        );
     }
 
     #[test]

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -167,6 +167,13 @@ impl ContinuousCDF<f64, f64> for Beta {
             0.0
         } else if prec::ulps_eq!(self.shape_a, 1.0) && prec::ulps_eq!(self.shape_b, 1.0) {
             1. - x
+        } else if x < (self.shape_a + 1.0) / (self.shape_a + self.shape_b + 2.0) {
+            // Below the continued fraction split point of `beta_reg`,
+            // `beta_reg(b, a, 1 - x)` reduces to `1 - beta_reg(a, b, x)`;
+            // computing the complement here instead avoids `1.0 - x`
+            // rounding to 1.0 for tiny x (< ~1.1e-16), which would lose
+            // the lower tail entirely. See #432 
+            1.0 - beta::beta_reg(self.shape_a, self.shape_b, x)
         } else {
             beta::beta_reg(self.shape_b, self.shape_a, 1.0 - x)
         }
@@ -611,6 +618,20 @@ mod tests {
             ((5.0, 100.0), 0.0, 1.0),
             ((5.0, 100.0), 0.5, 0.0),
             ((5.0, 100.0), 1.0, 0.0),
+            // Regression test for issue #432
+            // Reference values computed with mpmath at 60 decimal digits of precision.
+            ((0.05, 0.95), 1e-16, 0.84216163834910015),
+            ((0.05, 0.95), 1e-18, 0.87462453281806800),
+            ((0.05, 0.95), 1e-20, 0.90041072647564386),
+            ((0.05, 0.95), 1e-30, 0.96850710651415303),
+            ((0.05, 0.95), 1e-100, 0.99999004107264756),
+            ((0.05, 0.05), 1e-16, 0.92045095674306394),
+            ((0.05, 0.05), 1e-18, 0.93681194889571247),
+            ((0.05, 0.05), 1e-20, 0.94980794691066360),
+            ((0.05, 0.05), 1e-30, 0.98412787917976062),
+            ((0.05, 0.05), 1e-100, 0.99999498079469107),
+            ((2.0, 3.0), 1e-16, 1.0),
+            ((2.0, 3.0), 1e-100, 1.0),
         ];
         for ((a, b), x, expect) in test {
             test_relative(a, b, expect, sf(x));

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -598,6 +598,7 @@ mod tests {
     fn test_density_at_boundaries() {
         test_exact(0.5, 2.0, f64::INFINITY, |dist| dist.ln_pdf(0.0));
         test_exact(2.0, 0.5, f64::INFINITY, |dist| dist.ln_pdf(1.0));
+        test_relative(1.0, 2.0, 2.0_f64.ln(), |dist| dist.ln_pdf(0.0));
         test_exact(2.0, 3.0, f64::NEG_INFINITY, |dist| dist.ln_pdf(0.0));
         test_exact(2.0, 3.0, f64::NEG_INFINITY, |dist| dist.ln_pdf(1.0));
     }

--- a/src/distribution/binomial/mod.rs
+++ b/src/distribution/binomial/mod.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{beta, factorial};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 

--- a/src/distribution/binomial/mod.rs
+++ b/src/distribution/binomial/mod.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{beta, factorial};
-use crate::prec;
 use crate::statistics::*;
 use core::f64;
 #[cfg(not(feature = "std"))]
@@ -218,12 +217,12 @@ impl Distribution<f64> for Binomial {
     /// (1 / 2) * ln (2 * π * e * n * p * (1 - p))
     /// ```
     fn entropy(&self) -> Option<f64> {
-        let entr = if self.p == 0.0 || prec::ulps_eq!(self.p, 1.0) {
+        let entr = if self.p == 0.0 || self.p == 1.0 {
             0.0
         } else {
             (0..self.n + 1).fold(0.0, |acc, x| {
                 let p = self.pmf(x);
-                acc - p * p.ln()
+                if p == 0.0 { acc } else { acc - p * p.ln() }
             })
         };
         Some(entr)
@@ -265,7 +264,7 @@ impl Mode<Option<u64>> for Binomial {
     fn mode(&self) -> Option<u64> {
         let mode = if self.p == 0.0 {
             0
-        } else if prec::ulps_eq!(self.p, 1.0) {
+        } else if self.p == 1.0 {
             self.n
         } else {
             ((self.n as f64 + 1.0) * self.p).floor() as u64
@@ -288,7 +287,7 @@ impl Discrete<u64, f64> for Binomial {
             0.0
         } else if self.p == 0.0 {
             if x == 0 { 1.0 } else { 0.0 }
-        } else if prec::ulps_eq!(self.p, 1.0) {
+        } else if self.p == 1.0 {
             if x == self.n { 1.0 } else { 0.0 }
         } else {
             (factorial::ln_binomial(self.n, x)
@@ -311,7 +310,7 @@ impl Discrete<u64, f64> for Binomial {
             f64::NEG_INFINITY
         } else if self.p == 0.0 {
             if x == 0 { 0.0 } else { f64::NEG_INFINITY }
-        } else if prec::ulps_eq!(self.p, 1.0) {
+        } else if self.p == 1.0 {
             if x == self.n { 0.0 } else { f64::NEG_INFINITY }
         } else {
             factorial::ln_binomial(self.n, x)
@@ -326,6 +325,7 @@ impl Discrete<u64, f64> for Binomial {
 mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
+    use crate::prec;
     crate::distribution::internal::testing_boiler!(p: f64, n: u64; Binomial; BinomialError);
 
     #[test]
@@ -454,6 +454,20 @@ mod tests {
         test_exact(1.0, 10, f64::NEG_INFINITY, ln_pmf(0));
         test_exact(1.0, 10, f64::NEG_INFINITY, ln_pmf(1));
         test_exact(1.0, 10, 0.0, ln_pmf(10));
+    }
+
+    #[test]
+    fn test_probability_near_one_is_not_degenerate() {
+        let p = 1.0 - 5e-10;
+        let n = 10;
+        let dist = create_ok(p, n);
+        let expected = n as f64 * p.powi(n as i32 - 1) * (1.0 - p);
+        prec::assert_relative_eq!(dist.pmf(n - 1), expected);
+        prec::assert_relative_eq!(dist.ln_pmf(n - 1), expected.ln());
+        assert!(dist.entropy().unwrap() > 0.0);
+
+        let large_dist = create_ok(p, 1000);
+        assert!(large_dist.entropy().unwrap().is_finite());
     }
 
     #[test]

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::statistics::*;
-use core::f64;
 
 /// Implements the
 /// [Categorical](https://en.wikipedia.org/wiki/Categorical_distribution)

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -117,7 +116,7 @@ impl core::fmt::Display for Cauchy {
 impl ::rand::distr::Distribution<f64> for Cauchy {
     fn sample<R: ::rand::Rng + ?Sized>(&self, r: &mut R) -> f64 {
         let x = ::rand::RngExt::random::<f64>(r);
-        self.location + self.scale * (f64::consts::PI * (x - 0.5)).tan()
+        self.location + self.scale * (core::f64::consts::PI * (x - 0.5)).tan()
     }
 }
 
@@ -133,7 +132,7 @@ impl ContinuousCDF<f64, f64> for Cauchy {
     ///
     /// where `x_0` is the location and `γ` is the scale
     fn cdf(&self, x: f64) -> f64 {
-        (1.0 / f64::consts::PI) * ((x - self.location) / self.scale).atan() + 0.5
+        (1.0 / core::f64::consts::PI) * ((x - self.location) / self.scale).atan() + 0.5
     }
 
     /// Calculates the survival function for the
@@ -149,7 +148,7 @@ impl ContinuousCDF<f64, f64> for Cauchy {
     /// note that this is identical to the cdf except for
     /// the negative argument to the arctan function
     fn sf(&self, x: f64) -> f64 {
-        (1.0 / f64::consts::PI) * ((self.location - x) / self.scale).atan() + 0.5
+        (1.0 / core::f64::consts::PI) * ((self.location - x) / self.scale).atan() + 0.5
     }
 
     /// Calculates the inverse cumulative distribution function for the
@@ -166,7 +165,7 @@ impl ContinuousCDF<f64, f64> for Cauchy {
         if !(0.0..=1.0).contains(&x) {
             panic!("x must be in [0, 1]");
         } else {
-            self.location + self.scale * (f64::consts::PI * (x - 0.5)).tan()
+            self.location + self.scale * (core::f64::consts::PI * (x - 0.5)).tan()
         }
     }
 }
@@ -210,7 +209,7 @@ impl Distribution<f64> for Cauchy {
     ///
     /// where `γ` is the scale
     fn entropy(&self) -> Option<f64> {
-        Some((4.0 * f64::consts::PI * self.scale).ln())
+        Some((4.0 * core::f64::consts::PI * self.scale).ln())
     }
 }
 
@@ -256,7 +255,7 @@ impl Continuous<f64, f64> for Cauchy {
     ///
     /// where `x_0` is the location and `γ` is the scale
     fn pdf(&self, x: f64) -> f64 {
-        1.0 / (f64::consts::PI
+        1.0 / (core::f64::consts::PI
             * self.scale
             * (1.0 + ((x - self.location) / self.scale) * ((x - self.location) / self.scale)))
     }
@@ -272,7 +271,7 @@ impl Continuous<f64, f64> for Cauchy {
     ///
     /// where `x_0` is the location and `γ` is the scale
     fn ln_pdf(&self, x: f64) -> f64 {
-        -(f64::consts::PI
+        -(core::f64::consts::PI
             * self.scale
             * (1.0 + ((x - self.location) / self.scale) * ((x - self.location) / self.scale)))
             .ln()
@@ -357,7 +356,7 @@ mod tests {
         test_exact(0.0, 0.1, 0.001272730452554141029739, pdf(5.0));
         test_absolute(0.0, 1.0, 0.01224268793014579505914, 1e-17, pdf(-5.0));
         test_exact(0.0, 1.0, 0.1591549430918953357689, pdf(-1.0));
-        test_exact(0.0, 1.0, f64::consts::FRAC_1_PI, pdf(0.0));
+        test_exact(0.0, 1.0, core::f64::consts::FRAC_1_PI, pdf(0.0));
         test_exact(0.0, 1.0, 0.1591549430918953357689, pdf(1.0));
         test_absolute(0.0, 1.0, 0.01224268793014579505914, 1e-17, pdf(5.0));
         test_exact(0.0, 10.0, 0.02546479089470325372302, pdf(-5.0));

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -1,5 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -116,7 +117,7 @@ impl core::fmt::Display for Cauchy {
 impl ::rand::distr::Distribution<f64> for Cauchy {
     fn sample<R: ::rand::Rng + ?Sized>(&self, r: &mut R) -> f64 {
         let x = ::rand::RngExt::random::<f64>(r);
-        self.location + self.scale * (core::f64::consts::PI * (x - 0.5)).tan()
+        self.location + self.scale * (f64_consts::PI * (x - 0.5)).tan()
     }
 }
 
@@ -132,7 +133,7 @@ impl ContinuousCDF<f64, f64> for Cauchy {
     ///
     /// where `x_0` is the location and `γ` is the scale
     fn cdf(&self, x: f64) -> f64 {
-        (1.0 / core::f64::consts::PI) * ((x - self.location) / self.scale).atan() + 0.5
+        (1.0 / f64_consts::PI) * ((x - self.location) / self.scale).atan() + 0.5
     }
 
     /// Calculates the survival function for the
@@ -148,7 +149,7 @@ impl ContinuousCDF<f64, f64> for Cauchy {
     /// note that this is identical to the cdf except for
     /// the negative argument to the arctan function
     fn sf(&self, x: f64) -> f64 {
-        (1.0 / core::f64::consts::PI) * ((self.location - x) / self.scale).atan() + 0.5
+        (1.0 / f64_consts::PI) * ((self.location - x) / self.scale).atan() + 0.5
     }
 
     /// Calculates the inverse cumulative distribution function for the
@@ -165,7 +166,7 @@ impl ContinuousCDF<f64, f64> for Cauchy {
         if !(0.0..=1.0).contains(&x) {
             panic!("x must be in [0, 1]");
         } else {
-            self.location + self.scale * (core::f64::consts::PI * (x - 0.5)).tan()
+            self.location + self.scale * (f64_consts::PI * (x - 0.5)).tan()
         }
     }
 }
@@ -209,7 +210,7 @@ impl Distribution<f64> for Cauchy {
     ///
     /// where `γ` is the scale
     fn entropy(&self) -> Option<f64> {
-        Some((4.0 * core::f64::consts::PI * self.scale).ln())
+        Some((4.0 * f64_consts::PI * self.scale).ln())
     }
 }
 
@@ -255,7 +256,7 @@ impl Continuous<f64, f64> for Cauchy {
     ///
     /// where `x_0` is the location and `γ` is the scale
     fn pdf(&self, x: f64) -> f64 {
-        1.0 / (core::f64::consts::PI
+        1.0 / (f64_consts::PI
             * self.scale
             * (1.0 + ((x - self.location) / self.scale) * ((x - self.location) / self.scale)))
     }
@@ -271,7 +272,7 @@ impl Continuous<f64, f64> for Cauchy {
     ///
     /// where `x_0` is the location and `γ` is the scale
     fn ln_pdf(&self, x: f64) -> f64 {
-        -(core::f64::consts::PI
+        -(f64_consts::PI
             * self.scale
             * (1.0 + ((x - self.location) / self.scale) * ((x - self.location) / self.scale)))
             .ln()
@@ -293,6 +294,15 @@ mod tests {
         create_ok(10.0, 11.0);
         create_ok(-5.0, 100.0);
         create_ok(0.0, f64::INFINITY);
+    }
+
+    #[test]
+    #[cfg(feature = "rand")]
+    fn test_sample() {
+        use rand::{distr::Distribution as _, rngs::StdRng, SeedableRng};
+
+        let mut rng = StdRng::seed_from_u64(437);
+        assert!(create_ok(0.0, 1.0).sample(&mut rng).is_finite());
     }
 
     #[test]
@@ -356,7 +366,7 @@ mod tests {
         test_exact(0.0, 0.1, 0.001272730452554141029739, pdf(5.0));
         test_absolute(0.0, 1.0, 0.01224268793014579505914, 1e-17, pdf(-5.0));
         test_exact(0.0, 1.0, 0.1591549430918953357689, pdf(-1.0));
-        test_exact(0.0, 1.0, core::f64::consts::FRAC_1_PI, pdf(0.0));
+        test_exact(0.0, 1.0, f64_consts::FRAC_1_PI, pdf(0.0));
         test_exact(0.0, 1.0, 0.1591549430918953357689, pdf(1.0));
         test_absolute(0.0, 1.0, 0.01224268793014579505914, 1e-17, pdf(5.0));
         test_exact(0.0, 10.0, 0.02546479089470325372302, pdf(-5.0));

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::statistics::*;
-use core::f64;
 use core::num::NonZeroU64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
@@ -234,7 +233,7 @@ impl Distribution<f64> for Chi {
                         * (1.0 - 0.046875 / (freedom * freedom * freedom))),
             )
         } else {
-            let mean = f64::consts::SQRT_2 * gamma::gamma((freedom + 1.0) / 2.0)
+            let mean = core::f64::consts::SQRT_2 * gamma::gamma((freedom + 1.0) / 2.0)
                 / gamma::gamma(freedom / 2.0);
             Some(mean)
         }
@@ -425,7 +424,7 @@ mod tests {
         let mode = |x: Chi| x.mode().unwrap();
         test_exact(1, 0.0, mode);
         test_exact(2, 1.0, mode);
-        test_exact(3, f64::consts::SQRT_2, mode);
+        test_exact(3, core::f64::consts::SQRT_2, mode);
     }
 
     #[test]

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -1,6 +1,7 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 use core::num::NonZeroU64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
@@ -233,7 +234,7 @@ impl Distribution<f64> for Chi {
                         * (1.0 - 0.046875 / (freedom * freedom * freedom))),
             )
         } else {
-            let mean = core::f64::consts::SQRT_2 * gamma::gamma((freedom + 1.0) / 2.0)
+            let mean = f64_consts::SQRT_2 * gamma::gamma((freedom + 1.0) / 2.0)
                 / gamma::gamma(freedom / 2.0);
             Some(mean)
         }
@@ -424,7 +425,7 @@ mod tests {
         let mode = |x: Chi| x.mode().unwrap();
         test_exact(1, 0.0, mode);
         test_exact(2, 1.0, mode);
-        test_exact(3, core::f64::consts::SQRT_2, mode);
+        test_exact(3, f64_consts::SQRT_2, mode);
     }
 
     #[test]

--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF, Gamma, GammaError};
 use crate::statistics::*;
-use core::f64;
 
 /// Implements the
 /// [Chi-squared](https://en.wikipedia.org/wiki/Chi-squared_distribution)

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -2,7 +2,6 @@ use crate::distribution::Continuous;
 use crate::function::gamma;
 use crate::prec;
 use crate::statistics::*;
-use core::f64;
 use nalgebra::{Dim, Dyn, OMatrix, OVector};
 
 /// Implements the

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -1,5 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -239,7 +240,7 @@ impl Median<f64> for Exp {
     ///
     /// where `λ` is the rate
     fn median(&self) -> f64 {
-        core::f64::consts::LN_2 / self.rate
+        f64_consts::LN_2 / self.rate
     }
 }
 
@@ -354,7 +355,7 @@ mod tests {
     fn test_median() {
         let median = |x: Exp| x.median();
         test_absolute(0.1, 6.931471805599453094172, 1e-15, median);
-        test_exact(1.0, core::f64::consts::LN_2, median);
+        test_exact(1.0, f64_consts::LN_2, median);
         test_exact(10.0, 0.06931471805599453094172, median);
     }
 
@@ -408,9 +409,9 @@ mod tests {
     #[test]
     fn test_ln_pdf() {
         let ln_pdf = |arg: f64| move |x: Exp| x.ln_pdf(arg);
-        test_absolute(0.1, -core::f64::consts::LN_10, 1e-15, ln_pdf(0.0));
+        test_absolute(0.1, -f64_consts::LN_10, 1e-15, ln_pdf(0.0));
         test_exact(1.0, 0.0, ln_pdf(0.0));
-        test_exact(10.0, core::f64::consts::LN_10, ln_pdf(0.0));
+        test_exact(10.0, f64_consts::LN_10, ln_pdf(0.0));
         test_is_nan(f64::INFINITY, ln_pdf(0.0));
         test_absolute(0.1, -2.312585092994045684018, 1e-15, ln_pdf(0.1));
         test_exact(1.0, -0.1, ln_pdf(0.1));

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -240,7 +239,7 @@ impl Median<f64> for Exp {
     ///
     /// where `λ` is the rate
     fn median(&self) -> f64 {
-        f64::consts::LN_2 / self.rate
+        core::f64::consts::LN_2 / self.rate
     }
 }
 
@@ -355,7 +354,7 @@ mod tests {
     fn test_median() {
         let median = |x: Exp| x.median();
         test_absolute(0.1, 6.931471805599453094172, 1e-15, median);
-        test_exact(1.0, f64::consts::LN_2, median);
+        test_exact(1.0, core::f64::consts::LN_2, median);
         test_exact(10.0, 0.06931471805599453094172, median);
     }
 
@@ -409,9 +408,9 @@ mod tests {
     #[test]
     fn test_ln_pdf() {
         let ln_pdf = |arg: f64| move |x: Exp| x.ln_pdf(arg);
-        test_absolute(0.1, -f64::consts::LN_10, 1e-15, ln_pdf(0.0));
+        test_absolute(0.1, -core::f64::consts::LN_10, 1e-15, ln_pdf(0.0));
         test_exact(1.0, 0.0, ln_pdf(0.0));
-        test_exact(10.0, f64::consts::LN_10, ln_pdf(0.0));
+        test_exact(10.0, core::f64::consts::LN_10, ln_pdf(0.0));
         test_is_nan(f64::INFINITY, ln_pdf(0.0));
         test_absolute(0.1, -2.312585092994045684018, 1e-15, ln_pdf(0.1));
         test_exact(1.0, -0.1, ln_pdf(0.1));

--- a/src/distribution/fisher_snedecor.rs
+++ b/src/distribution/fisher_snedecor.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::beta;
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -148,7 +148,7 @@ impl ContinuousCDF<f64, f64> for Gamma {
     fn cdf(&self, x: f64) -> f64 {
         if x <= 0.0 {
             0.0
-        } else if prec::ulps_eq!(x, self.shape) && self.rate.is_infinite() {
+        } else if x == self.shape && self.rate.is_infinite() {
             1.0
         } else if self.rate.is_infinite() {
             0.0
@@ -173,7 +173,7 @@ impl ContinuousCDF<f64, f64> for Gamma {
     fn sf(&self, x: f64) -> f64 {
         if x <= 0.0 {
             1.0
-        } else if prec::ulps_eq!(x, self.shape) && self.rate.is_infinite() {
+        } else if x == self.shape && self.rate.is_infinite() {
             0.0
         } else if self.rate.is_infinite() {
             1.0
@@ -359,7 +359,7 @@ impl Continuous<f64, f64> for Gamma {
     fn pdf(&self, x: f64) -> f64 {
         if x < 0.0 {
             0.0
-        } else if prec::ulps_eq!(self.shape, 1.0) {
+        } else if self.shape == 1.0 {
             self.rate * (-self.rate * x).exp()
         } else if self.shape > 160.0 {
             self.ln_pdf(x).exp()
@@ -390,7 +390,7 @@ impl Continuous<f64, f64> for Gamma {
     fn ln_pdf(&self, x: f64) -> f64 {
         if x < 0.0 {
             f64::NEG_INFINITY
-        } else if prec::ulps_eq!(self.shape, 1.0) {
+        } else if self.shape == 1.0 {
             self.rate.ln() - self.rate * x
         } else if x.is_infinite() {
             f64::NEG_INFINITY
@@ -617,6 +617,14 @@ mod tests {
     }
 
     #[test]
+    fn test_pdf_at_zero_for_shape_near_one() {
+        test_exact(1.0 + 5e-10, 1.0, 0.0, |dist| dist.pdf(0.0));
+        test_exact(1.0 + 5e-10, 1.0, f64::NEG_INFINITY, |dist| dist.ln_pdf(0.0));
+        test_exact(1.0 - 5e-10, 1.0, f64::INFINITY, |dist| dist.pdf(0.0));
+        test_exact(1.0 - 5e-10, 1.0, f64::INFINITY, |dist| dist.ln_pdf(0.0));
+    }
+
+    #[test]
     fn test_ln_pdf() {
         let f = |arg: f64| move |x: Gamma| x.ln_pdf(arg);
         let test = [
@@ -660,6 +668,13 @@ mod tests {
     #[test]
     fn test_cdf_at_zero() {
         test_relative(1.0, 0.1, 0.0, |x| x.cdf(0.0));
+    }
+
+    #[test]
+    fn test_infinite_rate_special_point_is_exact() {
+        let dist = create_ok(10.0, f64::INFINITY);
+        assert_eq!(dist.cdf(10.0 - 5e-10), 0.0);
+        assert_eq!(dist.sf(10.0 - 5e-10), 1.0);
     }
 
     #[test]

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 use num_traits::{One, Zero};
@@ -310,7 +309,7 @@ impl Median<f64> for Geometric {
     /// ceil(-1 / log_2(1 - p))
     /// ```
     fn median(&self) -> f64 {
-        (-f64::consts::LN_2 / (1.0 - self.p).ln()).ceil()
+        (-core::f64::consts::LN_2 / (1.0 - self.p).ln()).ceil()
     }
 }
 

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -1,5 +1,4 @@
 use crate::distribution::{Discrete, DiscreteCDF};
-use crate::prec;
 use crate::statistics::*;
 use core::f64;
 #[cfg(not(feature = "std"))]
@@ -101,7 +100,7 @@ impl core::fmt::Display for Geometric {
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl ::rand::distr::Distribution<u64> for Geometric {
     fn sample<R: ::rand::Rng + ?Sized>(&self, r: &mut R) -> u64 {
-        if prec::ulps_eq!(self.p, 1.0) {
+        if self.p == 1.0 {
             1
         } else {
             let x: f64 = r.sample(::rand::distr::OpenClosed01);
@@ -185,7 +184,7 @@ impl DiscreteCDF<u64, f64> for Geometric {
         if !(<f64>::zero()..=<f64>::one()).contains(&x) {
             panic!("x must be in [0, 1]");
         }
-        if prec::ulps_eq!(self.p, 1.0) {
+        if self.p == 1.0 {
             // degenerate distribution: all mass at k=1
             return self.min();
         }
@@ -233,11 +232,7 @@ impl Max<u64> for Geometric {
     /// 2^63 - 1
     /// ```
     fn max(&self) -> u64 {
-        if prec::ulps_eq!(self.p, 1.0) {
-            1
-        } else {
-            u64::MAX
-        }
+        if self.p == 1.0 { 1 } else { u64::MAX }
     }
 }
 
@@ -284,7 +279,7 @@ impl Distribution<f64> for Geometric {
     /// (2 - p) / sqrt(1 - p)
     /// ```
     fn skewness(&self) -> Option<f64> {
-        if prec::ulps_eq!(self.p, 1.0) {
+        if self.p == 1.0 {
             return Some(f64::INFINITY);
         };
         Some((2.0 - self.p) / (1.0 - self.p).sqrt())
@@ -347,9 +342,9 @@ impl Discrete<u64, f64> for Geometric {
     fn ln_pmf(&self, x: u64) -> f64 {
         if x == 0 {
             f64::NEG_INFINITY
-        } else if prec::ulps_eq!(self.p, 1.0) && x == 1 {
+        } else if self.p == 1.0 && x == 1 {
             0.0
-        } else if prec::ulps_eq!(self.p, 1.0) {
+        } else if self.p == 1.0 {
             f64::NEG_INFINITY
         } else {
             ((x - 1) as f64 * (1.0 - self.p).ln()) + self.p.ln()
@@ -461,6 +456,16 @@ mod tests {
         test_absolute(0.3, -1.560647748264668371535, 1e-15, ln_pmf(2));
         test_exact(1.0, 0.0, ln_pmf(1));
         test_exact(1.0, f64::NEG_INFINITY, ln_pmf(2));
+    }
+
+    #[test]
+    fn test_probability_near_one_is_not_degenerate() {
+        let p = 1.0 - 5e-10;
+        let dist = create_ok(p);
+        assert_eq!(dist.max(), u64::MAX);
+        prec::assert_relative_eq!(dist.ln_pmf(2), ((1.0 - p) * p).ln());
+        assert!(dist.skewness().unwrap().is_finite());
+        assert_eq!(dist.inverse_cdf((1.0 + p) / 2.0), 2);
     }
 
     #[test]

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -1,5 +1,6 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 use num_traits::{One, Zero};
@@ -309,7 +310,7 @@ impl Median<f64> for Geometric {
     /// ceil(-1 / log_2(1 - p))
     /// ```
     fn median(&self) -> f64 {
-        (-core::f64::consts::LN_2 / (1.0 - self.p).ln()).ceil()
+        (-f64_consts::LN_2 / (1.0 - self.p).ln()).ceil()
     }
 }
 
@@ -364,6 +365,16 @@ mod tests {
     fn test_create() {
         create_ok(0.3);
         create_ok(1.0);
+    }
+
+    #[test]
+    #[cfg(feature = "rand")]
+    fn test_sample_degenerate() {
+        use rand::{distr::Distribution as _, rngs::StdRng, SeedableRng};
+
+        let mut rng = StdRng::seed_from_u64(437);
+        let sample: u64 = create_ok(1.0).sample(&mut rng);
+        assert_eq!(sample, 1);
     }
 
     #[test]

--- a/src/distribution/gumbel.rs
+++ b/src/distribution/gumbel.rs
@@ -1,7 +1,6 @@
 use super::{Continuous, ContinuousCDF};
 use crate::consts::EULER_MASCHERONI;
 use crate::statistics::*;
-use core::f64;
 use core::f64::consts::PI;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -2,7 +2,6 @@ use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::factorial;
 use crate::statistics::*;
 use core::cmp;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -541,11 +540,11 @@ mod tests {
         let ln_pmf = |arg: u64| move |x: Hypergeometric| x.ln_pmf(arg);
         test_exact(0, 0, 0, 0.0, ln_pmf(0));
         test_exact(1, 1, 1, 0.0, ln_pmf(1));
-        test_exact(2, 1, 1, -f64::consts::LN_2, ln_pmf(0));
-        test_exact(2, 1, 1, -f64::consts::LN_2, ln_pmf(1));
+        test_exact(2, 1, 1, -core::f64::consts::LN_2, ln_pmf(0));
+        test_exact(2, 1, 1, -core::f64::consts::LN_2, ln_pmf(1));
         test_exact(2, 2, 2, 0.0, ln_pmf(2));
         test_absolute(10, 1, 1, -0.1053605156578263012275, 1e-14, ln_pmf(0));
-        test_absolute(10, 1, 1, -f64::consts::LN_10, 1e-14, ln_pmf(1));
+        test_absolute(10, 1, 1, -core::f64::consts::LN_10, 1e-14, ln_pmf(1));
         test_absolute(10, 5, 3, -0.875468737353899935621, 1e-14, ln_pmf(1));
         test_absolute(10, 5, 3, -2.484906649788000310234, 1e-14, ln_pmf(3));
     }

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -427,6 +427,7 @@ mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
     use crate::distribution::internal::testing_boiler;
+    use core::f64::consts as f64_consts;
 
     testing_boiler!(population: u64, successes: u64, draws: u64; Hypergeometric; HypergeometricError);
 
@@ -540,11 +541,11 @@ mod tests {
         let ln_pmf = |arg: u64| move |x: Hypergeometric| x.ln_pmf(arg);
         test_exact(0, 0, 0, 0.0, ln_pmf(0));
         test_exact(1, 1, 1, 0.0, ln_pmf(1));
-        test_exact(2, 1, 1, -core::f64::consts::LN_2, ln_pmf(0));
-        test_exact(2, 1, 1, -core::f64::consts::LN_2, ln_pmf(1));
+        test_exact(2, 1, 1, -f64_consts::LN_2, ln_pmf(0));
+        test_exact(2, 1, 1, -f64_consts::LN_2, ln_pmf(1));
         test_exact(2, 2, 2, 0.0, ln_pmf(2));
         test_absolute(10, 1, 1, -0.1053605156578263012275, 1e-14, ln_pmf(0));
-        test_absolute(10, 1, 1, -core::f64::consts::LN_10, 1e-14, ln_pmf(1));
+        test_absolute(10, 1, 1, -f64_consts::LN_10, 1e-14, ln_pmf(1));
         test_absolute(10, 5, 3, -0.875468737353899935621, 1e-14, ln_pmf(1));
         test_absolute(10, 5, 3, -2.484906649788000310234, 1e-14, ln_pmf(3));
     }

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -524,7 +523,7 @@ mod tests {
         // p = 1 - 1e-12 (quantile ~6.4e23) where the old search lost all precision.
         let cases: &[(f64, f64, f64, f64)] = &[
             (1.0, 1.0, 1e-12, 0.03619120682527099),  (1.0, 1.0, 1e-6, 0.07238241365054197),
-            (1.0, 1.0, 1e-2, 0.21714724095162594),   (1.0, 1.0, 0.5, f64::consts::LOG2_E), // median = 1/ln 2
+            (1.0, 1.0, 1e-2, 0.21714724095162594),   (1.0, 1.0, 0.5, core::f64::consts::LOG2_E), // median = 1/ln 2
 
             (1.0, 1.0, 0.9999, 9999.499991667344),   (1.0, 1.0, 0.99999999, 99999998.99752413),
             (1.0, 1.0, 0.999999999999, 1000022122209.0044),

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -371,6 +371,7 @@ mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
     use crate::prec;
+    use core::f64::consts as f64_consts;
 
     testing_boiler!(shape: f64, rate: f64; InverseGamma; InverseGammaError);
 
@@ -523,7 +524,7 @@ mod tests {
         // p = 1 - 1e-12 (quantile ~6.4e23) where the old search lost all precision.
         let cases: &[(f64, f64, f64, f64)] = &[
             (1.0, 1.0, 1e-12, 0.03619120682527099),  (1.0, 1.0, 1e-6, 0.07238241365054197),
-            (1.0, 1.0, 1e-2, 0.21714724095162594),   (1.0, 1.0, 0.5, core::f64::consts::LOG2_E), // median = 1/ln 2
+            (1.0, 1.0, 1e-2, 0.21714724095162594),   (1.0, 1.0, 0.5, f64_consts::LOG2_E), // median = 1/ln 2
 
             (1.0, 1.0, 0.9999, 9999.499991667344),   (1.0, 1.0, 0.99999999, 99999998.99752413),
             (1.0, 1.0, 0.999999999999, 1000022122209.0044),

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
-use crate::prec;
 use crate::statistics::*;
 use core::f64;
 #[cfg(not(feature = "std"))]
@@ -344,7 +343,7 @@ impl Continuous<f64, f64> for InverseGamma {
     fn pdf(&self, x: f64) -> f64 {
         if x <= 0.0 || x.is_infinite() {
             0.0
-        } else if prec::ulps_eq!(self.shape, 1.0) {
+        } else if self.shape == 1.0 {
             self.rate / (x * x) * (-self.rate / x).exp()
         } else {
             self.rate.powf(self.shape) * x.powf(-self.shape - 1.0) * (-self.rate / x).exp()
@@ -372,7 +371,7 @@ impl Continuous<f64, f64> for InverseGamma {
 mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
-
+    use crate::prec;
 
     testing_boiler!(shape: f64, rate: f64; InverseGamma; InverseGammaError);
 
@@ -465,6 +464,22 @@ mod tests {
         test_absolute(0.1, 1.0, 0.0297426109178248997426, 1e-15, pdf(2.0));
         test_exact(1.0, 0.1, 0.04157808822362745501024, pdf(1.5));
         test_exact(1.0, 1.0, 0.3018043114632487660842, pdf(1.2));
+    }
+
+    #[test]
+    fn test_pdf_for_shape_near_one() {
+        let shape = 1.0 + 5e-10;
+        let rate = 1.0;
+        let x = 1.2_f64;
+        let dist = create_ok(shape, rate);
+        let expected = rate.powf(shape) * x.powf(-shape - 1.0) * (-rate / x).exp()
+            / gamma::gamma(shape);
+        prec::assert_relative_eq!(
+            dist.pdf(x),
+            expected,
+            epsilon = 1e-15,
+            max_relative = 1e-14
+        );
     }
 
     #[test]

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -322,6 +322,7 @@ impl Continuous<f64, f64> for Laplace {
 mod tests {
     use super::*;
     use crate::prec;
+    use core::f64::consts as f64_consts;
 
     testing_boiler!(location: f64, scale: f64; Laplace; LaplaceError);
 
@@ -382,13 +383,13 @@ mod tests {
         test_absolute(
             f64::NEG_INFINITY,
             0.1,
-            (2.0 * core::f64::consts::E * 0.1).ln(),
+            (2.0 * f64_consts::E * 0.1).ln(),
             1E-12,
             entropy,
         );
-        test_absolute(-6.0, 1.0, (2.0 * core::f64::consts::E).ln(), 1E-12, entropy);
-        test_absolute(1.0, 7.0, (2.0 * core::f64::consts::E * 7.0).ln(), 1E-12, entropy);
-        test_absolute(5., 10., (2. * core::f64::consts::E * 10.).ln(), 1E-12, entropy);
+        test_absolute(-6.0, 1.0, (2.0 * f64_consts::E).ln(), 1E-12, entropy);
+        test_absolute(1.0, 7.0, (2.0 * f64_consts::E * 7.0).ln(), 1E-12, entropy);
+        test_absolute(5., 10., (2. * f64_consts::E * 10.).ln(), 1E-12, entropy);
         test_absolute(f64::INFINITY, f64::INFINITY, f64::INFINITY, 1E-12, entropy);
     }
 
@@ -470,7 +471,7 @@ mod tests {
         test_exact(f64::NEG_INFINITY, 0.1, f64::NEG_INFINITY, ln_pdf(-0.0));
         test_exact(0.0, 1.0, f64::NEG_INFINITY, ln_pdf(f64::INFINITY));
         test_absolute(1.0, 1.0, -4.693147180559945, 1E-12, ln_pdf(5.0));
-        test_absolute(-1.0, 1.0, -core::f64::consts::LN_2, 1E-12, ln_pdf(-1.0));
+        test_absolute(-1.0, 1.0, -f64_consts::LN_2, 1E-12, ln_pdf(-1.0));
         test_absolute(5.0, 1.0, -6.693147180559945, 1E-12, ln_pdf(-1.0));
         test_absolute(-5.0, 1.0, -8.193147180559945, 1E-12, ln_pdf(2.5));
         test_exact(f64::INFINITY, 0.1, f64::NEG_INFINITY, ln_pdf(2.0));
@@ -540,7 +541,7 @@ mod tests {
         test_rel_close(loc, scale, expected, reltol, inverse_cdf(0.001));
 
         // Wolfram Alpha: Inverse CDF[LaplaceDistribution[0, 1], 95/100]
-        let expected = core::f64::consts::LN_10;
+        let expected = f64_consts::LN_10;
         test_rel_close(loc, scale, expected, reltol, inverse_cdf(0.95));
     }
 

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::{Distribution, Max, Median, Min, Mode};
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -383,13 +382,13 @@ mod tests {
         test_absolute(
             f64::NEG_INFINITY,
             0.1,
-            (2.0 * f64::consts::E * 0.1).ln(),
+            (2.0 * core::f64::consts::E * 0.1).ln(),
             1E-12,
             entropy,
         );
-        test_absolute(-6.0, 1.0, (2.0 * f64::consts::E).ln(), 1E-12, entropy);
-        test_absolute(1.0, 7.0, (2.0 * f64::consts::E * 7.0).ln(), 1E-12, entropy);
-        test_absolute(5., 10., (2. * f64::consts::E * 10.).ln(), 1E-12, entropy);
+        test_absolute(-6.0, 1.0, (2.0 * core::f64::consts::E).ln(), 1E-12, entropy);
+        test_absolute(1.0, 7.0, (2.0 * core::f64::consts::E * 7.0).ln(), 1E-12, entropy);
+        test_absolute(5., 10., (2. * core::f64::consts::E * 10.).ln(), 1E-12, entropy);
         test_absolute(f64::INFINITY, f64::INFINITY, f64::INFINITY, 1E-12, entropy);
     }
 
@@ -471,7 +470,7 @@ mod tests {
         test_exact(f64::NEG_INFINITY, 0.1, f64::NEG_INFINITY, ln_pdf(-0.0));
         test_exact(0.0, 1.0, f64::NEG_INFINITY, ln_pdf(f64::INFINITY));
         test_absolute(1.0, 1.0, -4.693147180559945, 1E-12, ln_pdf(5.0));
-        test_absolute(-1.0, 1.0, -f64::consts::LN_2, 1E-12, ln_pdf(-1.0));
+        test_absolute(-1.0, 1.0, -core::f64::consts::LN_2, 1E-12, ln_pdf(-1.0));
         test_absolute(5.0, 1.0, -6.693147180559945, 1E-12, ln_pdf(-1.0));
         test_absolute(-5.0, 1.0, -8.193147180559945, 1E-12, ln_pdf(2.5));
         test_exact(f64::INFINITY, 0.1, f64::NEG_INFINITY, ln_pdf(2.0));
@@ -541,7 +540,7 @@ mod tests {
         test_rel_close(loc, scale, expected, reltol, inverse_cdf(0.001));
 
         // Wolfram Alpha: Inverse CDF[LaplaceDistribution[0, 1], 95/100]
-        let expected = f64::consts::LN_10;
+        let expected = core::f64::consts::LN_10;
         test_rel_close(loc, scale, expected, reltol, inverse_cdf(0.95));
     }
 

--- a/src/distribution/levy.rs
+++ b/src/distribution/levy.rs
@@ -2,6 +2,7 @@ use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf::{erf, erfc, erfc_inv};
 
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -308,8 +309,7 @@ impl Continuous<f64, f64> for Levy {
             0.0
         } else {
             let diff = x - self.mu;
-            (self.c / core::f64::consts::TAU).sqrt() * (-((0.5 * self.c) / diff)).exp()
-                / diff.powf(1.5)
+            (self.c / f64_consts::TAU).sqrt() * (-((0.5 * self.c) / diff)).exp() / diff.powf(1.5)
         }
     }
 

--- a/src/distribution/levy.rs
+++ b/src/distribution/levy.rs
@@ -2,7 +2,6 @@ use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf::{erf, erfc, erfc_inv};
 
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -309,7 +308,8 @@ impl Continuous<f64, f64> for Levy {
             0.0
         } else {
             let diff = x - self.mu;
-            (self.c / f64::consts::TAU).sqrt() * (-((0.5 * self.c) / diff)).exp() / diff.powf(1.5)
+            (self.c / core::f64::consts::TAU).sqrt() * (-((0.5 * self.c) / diff)).exp()
+                / diff.powf(1.5)
         }
     }
 
@@ -338,7 +338,6 @@ impl Continuous<f64, f64> for Levy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::f64;
     use crate::distribution::internal::density_util;
     crate::distribution::internal::testing_boiler!(mu: f64, c: f64; Levy; LevyError);
 

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -2,6 +2,7 @@ use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf;
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -143,7 +144,7 @@ impl ContinuousCDF<f64, f64> for LogNormal {
         } else if x.is_infinite() {
             1.0
         } else {
-            0.5 * erf::erfc((self.location - x.ln()) / (self.scale * core::f64::consts::SQRT_2))
+            0.5 * erf::erfc((self.location - x.ln()) / (self.scale * f64_consts::SQRT_2))
         }
     }
 
@@ -173,7 +174,7 @@ impl ContinuousCDF<f64, f64> for LogNormal {
         } else if x.is_infinite() {
             0.0
         } else {
-            0.5 * erf::erfc((x.ln() - self.location) / (self.scale * core::f64::consts::SQRT_2))
+            0.5 * erf::erfc((x.ln() - self.location) / (self.scale * f64_consts::SQRT_2))
         }
     }
 
@@ -196,8 +197,7 @@ impl ContinuousCDF<f64, f64> for LogNormal {
         if p == 0.0 {
             0.0
         } else if p < 1.0 {
-            (self.location - (self.scale * core::f64::consts::SQRT_2 * erf::erfc_inv(2.0 * p)))
-                .exp()
+            (self.location - (self.scale * f64_consts::SQRT_2 * erf::erfc_inv(2.0 * p))).exp()
         } else if p == 1.0 {
             f64::INFINITY
         } else {

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -2,7 +2,6 @@ use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf;
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -144,7 +143,7 @@ impl ContinuousCDF<f64, f64> for LogNormal {
         } else if x.is_infinite() {
             1.0
         } else {
-            0.5 * erf::erfc((self.location - x.ln()) / (self.scale * f64::consts::SQRT_2))
+            0.5 * erf::erfc((self.location - x.ln()) / (self.scale * core::f64::consts::SQRT_2))
         }
     }
 
@@ -174,7 +173,7 @@ impl ContinuousCDF<f64, f64> for LogNormal {
         } else if x.is_infinite() {
             0.0
         } else {
-            0.5 * erf::erfc((x.ln() - self.location) / (self.scale * f64::consts::SQRT_2))
+            0.5 * erf::erfc((x.ln() - self.location) / (self.scale * core::f64::consts::SQRT_2))
         }
     }
 
@@ -197,7 +196,8 @@ impl ContinuousCDF<f64, f64> for LogNormal {
         if p == 0.0 {
             0.0
         } else if p < 1.0 {
-            (self.location - (self.scale * f64::consts::SQRT_2 * erf::erfc_inv(2.0 * p))).exp()
+            (self.location - (self.scale * core::f64::consts::SQRT_2 * erf::erfc_inv(2.0 * p)))
+                .exp()
         } else if p == 1.0 {
             f64::INFINITY
         } else {

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -1,6 +1,5 @@
 use crate::distribution::Continuous;
 use crate::statistics::{Max, MeanN, Min, Mode, VarianceN};
-use core::f64;
 use core::f64::consts::{E, PI};
 use nalgebra::{Cholesky, Const, DMatrix, DVector, Dim, DimMin, Dyn, OMatrix, OVector};
 

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{beta, gamma};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -2,7 +2,6 @@ use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf;
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -175,7 +174,7 @@ impl ContinuousCDF<f64, f64> for Normal {
         if !(0.0..=1.0).contains(&x) {
             panic!("x must be in [0, 1]");
         } else {
-            self.mean - (self.std_dev * f64::consts::SQRT_2 * erf::erfc_inv(2.0 * x))
+            self.mean - (self.std_dev * core::f64::consts::SQRT_2 * erf::erfc_inv(2.0 * x))
         }
     }
 }
@@ -327,13 +326,13 @@ impl Continuous<f64, f64> for Normal {
 /// performs an unchecked cdf calculation for a normal distribution
 /// with the given mean and standard deviation at x
 pub fn cdf_unchecked(x: f64, mean: f64, std_dev: f64) -> f64 {
-    0.5 * erf::erfc((mean - x) / (std_dev * f64::consts::SQRT_2))
+    0.5 * erf::erfc((mean - x) / (std_dev * core::f64::consts::SQRT_2))
 }
 
 /// performs an unchecked sf calculation for a normal distribution
 /// with the given mean and standard deviation at x
 pub fn sf_unchecked(x: f64, mean: f64, std_dev: f64) -> f64 {
-    0.5 * erf::erfc((x - mean) / (std_dev * f64::consts::SQRT_2))
+    0.5 * erf::erfc((x - mean) / (std_dev * core::f64::consts::SQRT_2))
 }
 
 /// performs an unchecked pdf calculation for a normal distribution

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -2,6 +2,7 @@ use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf;
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -174,7 +175,7 @@ impl ContinuousCDF<f64, f64> for Normal {
         if !(0.0..=1.0).contains(&x) {
             panic!("x must be in [0, 1]");
         } else {
-            self.mean - (self.std_dev * core::f64::consts::SQRT_2 * erf::erfc_inv(2.0 * x))
+            self.mean - (self.std_dev * f64_consts::SQRT_2 * erf::erfc_inv(2.0 * x))
         }
     }
 }
@@ -326,13 +327,13 @@ impl Continuous<f64, f64> for Normal {
 /// performs an unchecked cdf calculation for a normal distribution
 /// with the given mean and standard deviation at x
 pub fn cdf_unchecked(x: f64, mean: f64, std_dev: f64) -> f64 {
-    0.5 * erf::erfc((mean - x) / (std_dev * core::f64::consts::SQRT_2))
+    0.5 * erf::erfc((mean - x) / (std_dev * f64_consts::SQRT_2))
 }
 
 /// performs an unchecked sf calculation for a normal distribution
 /// with the given mean and standard deviation at x
 pub fn sf_unchecked(x: f64, mean: f64, std_dev: f64) -> f64 {
-    0.5 * erf::erfc((x - mean) / (std_dev * core::f64::consts::SQRT_2))
+    0.5 * erf::erfc((x - mean) / (std_dev * f64_consts::SQRT_2))
 }
 
 /// performs an unchecked pdf calculation for a normal distribution

--- a/src/distribution/pareto.rs
+++ b/src/distribution/pareto.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{factorial, gamma};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -213,7 +212,7 @@ impl Distribution<f64> for Poisson {
     /// where `λ` is the rate
     fn entropy(&self) -> Option<f64> {
         Some(
-            0.5 * (2.0 * f64::consts::PI * f64::consts::E * self.lambda).ln()
+            0.5 * (2.0 * core::f64::consts::PI * core::f64::consts::E * self.lambda).ln()
                 - 1.0 / (12.0 * self.lambda)
                 - 1.0 / (24.0 * self.lambda * self.lambda)
                 - 19.0 / (360.0 * self.lambda * self.lambda * self.lambda),
@@ -316,7 +315,7 @@ pub fn sample_unchecked<R: ::rand::Rng + ?Sized>(rng: &mut R, lambda: f64) -> f6
         count
     } else {
         let c = 0.767 - 3.36 / lambda;
-        let beta = f64::consts::PI / (3.0 * lambda).sqrt();
+        let beta = core::f64::consts::PI / (3.0 * lambda).sqrt();
         let alpha = beta * lambda;
         let k = c.ln() - lambda - beta.ln();
 

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -1,6 +1,7 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{factorial, gamma};
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -212,7 +213,7 @@ impl Distribution<f64> for Poisson {
     /// where `λ` is the rate
     fn entropy(&self) -> Option<f64> {
         Some(
-            0.5 * (2.0 * core::f64::consts::PI * core::f64::consts::E * self.lambda).ln()
+            0.5 * (2.0 * f64_consts::PI * f64_consts::E * self.lambda).ln()
                 - 1.0 / (12.0 * self.lambda)
                 - 1.0 / (24.0 * self.lambda * self.lambda)
                 - 19.0 / (360.0 * self.lambda * self.lambda * self.lambda),
@@ -315,7 +316,7 @@ pub fn sample_unchecked<R: ::rand::Rng + ?Sized>(rng: &mut R, lambda: f64) -> f6
         count
     } else {
         let c = 0.767 - 3.36 / lambda;
-        let beta = core::f64::consts::PI / (3.0 * lambda).sqrt();
+        let beta = f64_consts::PI / (3.0 * lambda).sqrt();
         let alpha = beta * lambda;
         let k = c.ln() - lambda - beta.ln();
 
@@ -351,6 +352,18 @@ mod tests {
         create_ok(1.5);
         create_ok(5.4);
         create_ok(10.8);
+    }
+
+    #[test]
+    #[cfg(feature = "rand")]
+    fn test_sample_large_lambda() {
+        use rand::{rngs::StdRng, SeedableRng};
+
+        let mut rng = StdRng::seed_from_u64(437);
+        let sample = sample_unchecked(&mut rng, 30.0);
+        assert!(sample.is_finite());
+        assert!(sample >= 0.0);
+        assert_eq!(sample.fract(), 0.0);
     }
 
     #[test]

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::{beta, gamma};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -409,7 +408,7 @@ impl Continuous<f64, f64> for StudentsT {
             (gamma::ln_gamma((self.freedom + 1.0) / 2.0) - gamma::ln_gamma(self.freedom / 2.0))
                 .exp()
                 * (1.0 + d * d / self.freedom).powf(-0.5 * (self.freedom + 1.0))
-                / (self.freedom * f64::consts::PI).sqrt()
+                / (self.freedom * core::f64::consts::PI).sqrt()
                 / self.scale
         }
     }
@@ -438,7 +437,7 @@ impl Continuous<f64, f64> for StudentsT {
             gamma::ln_gamma((self.freedom + 1.0) / 2.0)
                 - 0.5 * ((self.freedom + 1.0) * (1.0 + d * d / self.freedom).ln())
                 - gamma::ln_gamma(self.freedom / 2.0)
-                - 0.5 * (self.freedom * f64::consts::PI).ln()
+                - 0.5 * (self.freedom * core::f64::consts::PI).ln()
                 - self.scale.ln()
         }
     }

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -1,6 +1,7 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::{beta, gamma};
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -408,7 +409,7 @@ impl Continuous<f64, f64> for StudentsT {
             (gamma::ln_gamma((self.freedom + 1.0) / 2.0) - gamma::ln_gamma(self.freedom / 2.0))
                 .exp()
                 * (1.0 + d * d / self.freedom).powf(-0.5 * (self.freedom + 1.0))
-                / (self.freedom * core::f64::consts::PI).sqrt()
+                / (self.freedom * f64_consts::PI).sqrt()
                 / self.scale
         }
     }
@@ -437,7 +438,7 @@ impl Continuous<f64, f64> for StudentsT {
             gamma::ln_gamma((self.freedom + 1.0) / 2.0)
                 - 0.5 * ((self.freedom + 1.0) * (1.0 + d * d / self.freedom).ln())
                 - gamma::ln_gamma(self.freedom / 2.0)
-                - 0.5 * (self.freedom * core::f64::consts::PI).ln()
+                - 0.5 * (self.freedom * f64_consts::PI).ln()
                 - self.scale.ln()
         }
     }
@@ -588,7 +589,7 @@ mod tests {
     #[test]
     fn test_pdf() {
         let pdf = |arg: f64| move |x: StudentsT| x.pdf(arg);
-        test_relative(0.0, 1.0, 1.0, core::f64::consts::FRAC_1_PI, pdf(0.0));
+        test_relative(0.0, 1.0, 1.0, f64_consts::FRAC_1_PI, pdf(0.0));
         test_relative(0.0, 1.0, 1.0, 0.159154943091895, pdf(1.0));
         test_relative(0.0, 1.0, 1.0, 0.159154943091895, pdf(-1.0));
         test_relative(0.0, 1.0, 1.0, 0.063661977236758, pdf(2.0));

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -1,5 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -326,8 +327,7 @@ impl Distribution<f64> for Triangular {
         let a = self.min;
         let b = self.max;
         let c = self.mode;
-        let q =
-            core::f64::consts::SQRT_2 * (a + b - 2.0 * c) * (2.0 * a - b - c) * (a - 2.0 * b + c);
+        let q = f64_consts::SQRT_2 * (a + b - 2.0 * c) * (2.0 * a - b - c) * (a - 2.0 * b + c);
         let d = 5.0 * (a * a + b * b + c * c - a * b - a * c - b * c).powf(3.0 / 2.0);
         Some(q / d)
     }

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -327,7 +326,8 @@ impl Distribution<f64> for Triangular {
         let a = self.min;
         let b = self.max;
         let c = self.mode;
-        let q = f64::consts::SQRT_2 * (a + b - 2.0 * c) * (2.0 * a - b - c) * (a - 2.0 * b + c);
+        let q =
+            core::f64::consts::SQRT_2 * (a + b - 2.0 * c) * (2.0 * a - b - c) * (a - 2.0 * b + c);
         let d = 5.0 * (a * a + b * b + c * c - a * b - a * c - b * c).powf(3.0 / 2.0);
         Some(q / d)
     }

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -66,7 +65,6 @@ impl Uniform {
     ///
     /// ```
     /// use statrs::distribution::Uniform;
-    /// use core::f64;
     ///
     /// let mut result = Uniform::new(0.0, 1.0);
     /// assert!(result.is_ok());
@@ -388,8 +386,8 @@ mod tests {
     #[test]
     fn test_entropy() {
         let entropy = |x: Uniform| x.entropy().unwrap();
-        test_exact(-0.0, 2.0, f64::consts::LN_2, entropy);
-        test_exact(0.0, 2.0, f64::consts::LN_2, entropy);
+        test_exact(-0.0, 2.0, core::f64::consts::LN_2, entropy);
+        test_exact(0.0, 2.0, core::f64::consts::LN_2, entropy);
         test_absolute(0.1, 4.0, 1.360976553135600743431, 1e-15, entropy);
         test_exact(1.0, 10.0, 2.19722457733621938279, entropy);
         test_exact(10.0, 11.0, 0.0, entropy);
@@ -448,14 +446,14 @@ mod tests {
     fn test_ln_pdf() {
         let ln_pdf = |arg: f64| move |x: Uniform| x.ln_pdf(arg);
         test_exact(0.0, 0.1, f64::NEG_INFINITY, ln_pdf(-5.0));
-        test_absolute(0.0, 0.1, f64::consts::LN_10, 1e-15, ln_pdf(0.05));
+        test_absolute(0.0, 0.1, core::f64::consts::LN_10, 1e-15, ln_pdf(0.05));
         test_exact(0.0, 0.1, f64::NEG_INFINITY, ln_pdf(5.0));
         test_exact(0.0, 1.0, f64::NEG_INFINITY, ln_pdf(-5.0));
         test_exact(0.0, 1.0, 0.0, ln_pdf(0.5));
         test_exact(0.0, 0.1, f64::NEG_INFINITY, ln_pdf(5.0));
         test_exact(0.0, 10.0, f64::NEG_INFINITY, ln_pdf(-5.0));
-        test_exact(0.0, 10.0, -f64::consts::LN_10, ln_pdf(1.0));
-        test_exact(0.0, 10.0, -f64::consts::LN_10, ln_pdf(5.0));
+        test_exact(0.0, 10.0, -core::f64::consts::LN_10, ln_pdf(1.0));
+        test_exact(0.0, 10.0, -core::f64::consts::LN_10, ln_pdf(5.0));
         test_exact(0.0, 10.0, f64::NEG_INFINITY, ln_pdf(11.0));
         test_exact(-5.0, 100.0, f64::NEG_INFINITY, ln_pdf(-10.0));
         test_exact(-5.0, 100.0, -4.653960350157523371101, ln_pdf(-5.0));

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -346,6 +346,7 @@ impl Continuous<f64, f64> for Uniform {
 mod tests {
     use super::*;
     use crate::prec;
+    use core::f64::consts as f64_consts;
     use crate::distribution::internal::density_util;
 
     testing_boiler!(min: f64, max: f64; Uniform; UniformError);
@@ -386,8 +387,8 @@ mod tests {
     #[test]
     fn test_entropy() {
         let entropy = |x: Uniform| x.entropy().unwrap();
-        test_exact(-0.0, 2.0, core::f64::consts::LN_2, entropy);
-        test_exact(0.0, 2.0, core::f64::consts::LN_2, entropy);
+        test_exact(-0.0, 2.0, f64_consts::LN_2, entropy);
+        test_exact(0.0, 2.0, f64_consts::LN_2, entropy);
         test_absolute(0.1, 4.0, 1.360976553135600743431, 1e-15, entropy);
         test_exact(1.0, 10.0, 2.19722457733621938279, entropy);
         test_exact(10.0, 11.0, 0.0, entropy);
@@ -446,14 +447,14 @@ mod tests {
     fn test_ln_pdf() {
         let ln_pdf = |arg: f64| move |x: Uniform| x.ln_pdf(arg);
         test_exact(0.0, 0.1, f64::NEG_INFINITY, ln_pdf(-5.0));
-        test_absolute(0.0, 0.1, core::f64::consts::LN_10, 1e-15, ln_pdf(0.05));
+        test_absolute(0.0, 0.1, f64_consts::LN_10, 1e-15, ln_pdf(0.05));
         test_exact(0.0, 0.1, f64::NEG_INFINITY, ln_pdf(5.0));
         test_exact(0.0, 1.0, f64::NEG_INFINITY, ln_pdf(-5.0));
         test_exact(0.0, 1.0, 0.0, ln_pdf(0.5));
         test_exact(0.0, 0.1, f64::NEG_INFINITY, ln_pdf(5.0));
         test_exact(0.0, 10.0, f64::NEG_INFINITY, ln_pdf(-5.0));
-        test_exact(0.0, 10.0, -core::f64::consts::LN_10, ln_pdf(1.0));
-        test_exact(0.0, 10.0, -core::f64::consts::LN_10, ln_pdf(5.0));
+        test_exact(0.0, 10.0, -f64_consts::LN_10, ln_pdf(1.0));
+        test_exact(0.0, 10.0, -f64_consts::LN_10, ln_pdf(5.0));
         test_exact(0.0, 10.0, f64::NEG_INFINITY, ln_pdf(11.0));
         test_exact(-5.0, 100.0, f64::NEG_INFINITY, ln_pdf(-10.0));
         test_exact(-5.0, 100.0, -4.653960350157523371101, ln_pdf(-5.0));

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -2,7 +2,6 @@ use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::statistics::*;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -297,7 +296,7 @@ impl Median<f64> for Weibull {
     ///
     /// where `k` is the shape and `λ` is the scale
     fn median(&self) -> f64 {
-        self.scale * f64::consts::LN_2.powf(1.0 / self.shape)
+        self.scale * core::f64::consts::LN_2.powf(1.0 / self.shape)
     }
 }
 
@@ -445,7 +444,7 @@ mod tests {
     fn test_median() {
         let median = |x: Weibull| x.median();
         test_exact(1.0, 0.1, 0.069314718055994530941723212145817656807550013436026, median);
-        test_exact(1.0, 1.0, f64::consts::LN_2, median);
+        test_exact(1.0, 1.0, core::f64::consts::LN_2, median);
         test_exact(10.0, 10.0, 9.6401223546778973665856033763604752124634905617583, median);
         test_exact(10.0, 1.0, 0.96401223546778973665856033763604752124634905617583, median);
     }
@@ -496,7 +495,7 @@ mod tests {
     #[test]
     fn test_ln_pdf() {
         let ln_pdf = |arg: f64| move |x: Weibull| x.ln_pdf(arg);
-        test_absolute(1.0, 0.1, f64::consts::LN_10, 1e-15, ln_pdf(0.0));
+        test_absolute(1.0, 0.1, core::f64::consts::LN_10, 1e-15, ln_pdf(0.0));
         test_absolute(1.0, 0.1, -7.6974149070059543159820085453156357923988985113712, 1e-15, ln_pdf(1.0));
         test_exact(1.0, 0.1, -97.697414907005954315982008545315635792398898511371, ln_pdf(10.0));
         test_exact(1.0, 1.0, 0.0, ln_pdf(0.0));

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -2,6 +2,7 @@ use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::statistics::*;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -296,7 +297,7 @@ impl Median<f64> for Weibull {
     ///
     /// where `k` is the shape and `λ` is the scale
     fn median(&self) -> f64 {
-        self.scale * core::f64::consts::LN_2.powf(1.0 / self.shape)
+        self.scale * f64_consts::LN_2.powf(1.0 / self.shape)
     }
 }
 
@@ -444,7 +445,7 @@ mod tests {
     fn test_median() {
         let median = |x: Weibull| x.median();
         test_exact(1.0, 0.1, 0.069314718055994530941723212145817656807550013436026, median);
-        test_exact(1.0, 1.0, core::f64::consts::LN_2, median);
+        test_exact(1.0, 1.0, f64_consts::LN_2, median);
         test_exact(10.0, 10.0, 9.6401223546778973665856033763604752124634905617583, median);
         test_exact(10.0, 1.0, 0.96401223546778973665856033763604752124634905617583, median);
     }
@@ -495,7 +496,7 @@ mod tests {
     #[test]
     fn test_ln_pdf() {
         let ln_pdf = |arg: f64| move |x: Weibull| x.ln_pdf(arg);
-        test_absolute(1.0, 0.1, core::f64::consts::LN_10, 1e-15, ln_pdf(0.0));
+        test_absolute(1.0, 0.1, f64_consts::LN_10, 1e-15, ln_pdf(0.0));
         test_absolute(1.0, 0.1, -7.6974149070059543159820085453156357923988985113712, 1e-15, ln_pdf(1.0));
         test_exact(1.0, 0.1, -97.697414907005954315982008545315635792398898511371, ln_pdf(10.0));
         test_exact(1.0, 1.0, 0.0, ln_pdf(0.0));

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -1,7 +1,6 @@
 use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
-use crate::prec;
 use crate::statistics::*;
 use core::f64;
 #[cfg(not(feature = "std"))]
@@ -317,7 +316,7 @@ impl Mode<Option<f64>> for Weibull {
     ///
     /// where `k` is the shape and `λ` is the scale
     fn mode(&self) -> Option<f64> {
-        let mode = if prec::ulps_eq!(self.shape, 1.0) {
+        let mode = if self.shape <= 1.0 {
             0.0
         } else {
             self.scale * ((self.shape - 1.0) / self.shape).powf(1.0 / self.shape)
@@ -340,7 +339,7 @@ impl Continuous<f64, f64> for Weibull {
     fn pdf(&self, x: f64) -> f64 {
         if x < 0.0 {
             0.0
-        } else if x == 0.0 && prec::ulps_eq!(self.shape, 1.0) {
+        } else if x == 0.0 && self.shape == 1.0 {
             1.0 / self.scale
         } else if x.is_infinite() {
             0.0
@@ -365,7 +364,7 @@ impl Continuous<f64, f64> for Weibull {
     fn ln_pdf(&self, x: f64) -> f64 {
         if x < 0.0 {
             f64::NEG_INFINITY
-        } else if x == 0.0 && prec::ulps_eq!(self.shape, 1.0) {
+        } else if x == 0.0 && self.shape == 1.0 {
             0.0 - self.scale.ln()
         } else if x.is_infinite() {
             f64::NEG_INFINITY
@@ -458,6 +457,7 @@ mod tests {
         test_exact(1.0, 1.0, 0.0, mode);
         test_exact(10.0, 10.0, 9.8951925820621439264623017041980483215553841533709, mode);
         test_exact(10.0, 1.0, 0.98951925820621439264623017041980483215553841533709, mode);
+        test_exact(0.5, 1.0, 0.0, mode);
     }
 
     #[test]
@@ -483,6 +483,14 @@ mod tests {
         test_exact(10.0, 1.0, 0.0, pdf(0.0));
         test_exact(10.0, 1.0, 3.6787944117144232159552377016146086744581113103177, pdf(1.0));
         test_exact(10.0, 1.0, 0.0, pdf(10.0));
+    }
+
+    #[test]
+    fn test_density_at_zero_for_shape_near_one() {
+        test_exact(1.0 + 5e-10, 1.0, 0.0, |dist| dist.pdf(0.0));
+        test_exact(1.0 + 5e-10, 1.0, f64::NEG_INFINITY, |dist| dist.ln_pdf(0.0));
+        test_exact(1.0 - 5e-10, 1.0, f64::INFINITY, |dist| dist.pdf(0.0));
+        test_exact(1.0 - 5e-10, 1.0, f64::INFINITY, |dist| dist.ln_pdf(0.0));
     }
 
     #[test]

--- a/src/function/beta.rs
+++ b/src/function/beta.rs
@@ -5,7 +5,6 @@
 
 use crate::function::gamma;
 use crate::prec;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -447,9 +446,9 @@ mod tests {
     #[test]
     fn test_ln_beta() {
         beta_assert_relative_eq(ln_beta(0.5, 0.5), 1.144729885849400174144);
-        beta_assert_relative_eq(ln_beta(1.0, 0.5), f64::consts::LN_2);
+        beta_assert_relative_eq(ln_beta(1.0, 0.5), core::f64::consts::LN_2);
         beta_assert_relative_eq(ln_beta(2.5, 0.5), 0.163900632837673937284);
-        beta_assert_relative_eq(ln_beta(0.5, 1.0), f64::consts::LN_2);
+        beta_assert_relative_eq(ln_beta(0.5, 1.0), core::f64::consts::LN_2);
         beta_assert_relative_eq(ln_beta(1.0, 1.0), 0.0);
         beta_assert_relative_eq(ln_beta(2.5, 1.0), -0.9162907318741550651835);
         beta_assert_relative_eq(ln_beta(0.5, 2.5), 0.163900632837673937284);
@@ -503,7 +502,7 @@ mod tests {
 
     #[test]
     fn test_beta() {
-        beta_assert_relative_eq(beta(0.5, 0.5), f64::consts::PI);
+        beta_assert_relative_eq(beta(0.5, 0.5), core::f64::consts::PI);
         beta_assert_relative_eq(beta(1.0, 0.5), 2.0);
         beta_assert_relative_eq(beta(2.5, 0.5), 1.17809724509617246442);
         beta_assert_relative_eq(beta(0.5, 1.0), 2.0);
@@ -516,13 +515,13 @@ mod tests {
 
     #[test]
     fn test_beta_inc() {
-        beta_assert_relative_eq(beta_inc(0.5, 0.5, 0.5), f64::consts::FRAC_PI_2);
-        beta_assert_relative_eq(beta_inc(0.5, 0.5, 1.0), f64::consts::PI);
+        beta_assert_relative_eq(beta_inc(0.5, 0.5, 0.5), core::f64::consts::FRAC_PI_2);
+        beta_assert_relative_eq(beta_inc(0.5, 0.5, 1.0), core::f64::consts::PI);
         beta_assert_relative_eq(beta_inc(1.0, 0.5, 0.5), 0.5857864376269049511983);
         beta_assert_relative_eq(beta_inc(1.0, 0.5, 1.0), 2.0);
         beta_assert_relative_eq(beta_inc(2.5, 0.5, 0.5), 0.0890486225480862322117);
         beta_assert_relative_eq(beta_inc(2.5, 0.5, 1.0), 1.17809724509617246442);
-        beta_assert_relative_eq(beta_inc(0.5, 1.0, 0.5), f64::consts::SQRT_2);
+        beta_assert_relative_eq(beta_inc(0.5, 1.0, 0.5), core::f64::consts::SQRT_2);
         beta_assert_relative_eq(beta_inc(0.5, 1.0, 1.0), 2.0);
         beta_assert_relative_eq(beta_inc(1.0, 1.0, 0.5), 0.5);
         beta_assert_relative_eq(beta_inc(1.0, 1.0, 1.0), 1.0);
@@ -588,7 +587,7 @@ mod tests {
         assert_eq!(beta_reg(1.0, 0.5, 1.0), 1.0);
         beta_assert_abs_diff_eq(beta_reg(2.5, 0.5, 0.5), 0.07558681842161243795);
         assert_eq!(beta_reg(2.5, 0.5, 1.0), 1.0);
-        beta_assert_abs_diff_eq(beta_reg(0.5, 1.0, 0.5), f64::consts::FRAC_1_SQRT_2);
+        beta_assert_abs_diff_eq(beta_reg(0.5, 1.0, 0.5), core::f64::consts::FRAC_1_SQRT_2);
         assert_eq!(beta_reg(0.5, 1.0, 1.0), 1.0);
         beta_assert_abs_diff_eq(beta_reg(1.0, 1.0, 0.5), 0.5);
         assert_eq!(beta_reg(1.0, 1.0, 1.0), 1.0);

--- a/src/function/beta.rs
+++ b/src/function/beta.rs
@@ -428,6 +428,7 @@ pub fn inv_beta_reg(mut a: f64, mut b: f64, mut x: f64) -> f64 {
 mod tests {
     use super::*;
     use crate::prec;
+    use core::f64::consts as f64_consts;
     const MODULE_RELATIVE_ACC: f64 = 1e-14;
 
     fn beta_assert_relative_eq(a: f64, b: f64) {
@@ -446,9 +447,9 @@ mod tests {
     #[test]
     fn test_ln_beta() {
         beta_assert_relative_eq(ln_beta(0.5, 0.5), 1.144729885849400174144);
-        beta_assert_relative_eq(ln_beta(1.0, 0.5), core::f64::consts::LN_2);
+        beta_assert_relative_eq(ln_beta(1.0, 0.5), f64_consts::LN_2);
         beta_assert_relative_eq(ln_beta(2.5, 0.5), 0.163900632837673937284);
-        beta_assert_relative_eq(ln_beta(0.5, 1.0), core::f64::consts::LN_2);
+        beta_assert_relative_eq(ln_beta(0.5, 1.0), f64_consts::LN_2);
         beta_assert_relative_eq(ln_beta(1.0, 1.0), 0.0);
         beta_assert_relative_eq(ln_beta(2.5, 1.0), -0.9162907318741550651835);
         beta_assert_relative_eq(ln_beta(0.5, 2.5), 0.163900632837673937284);
@@ -502,7 +503,7 @@ mod tests {
 
     #[test]
     fn test_beta() {
-        beta_assert_relative_eq(beta(0.5, 0.5), core::f64::consts::PI);
+        beta_assert_relative_eq(beta(0.5, 0.5), f64_consts::PI);
         beta_assert_relative_eq(beta(1.0, 0.5), 2.0);
         beta_assert_relative_eq(beta(2.5, 0.5), 1.17809724509617246442);
         beta_assert_relative_eq(beta(0.5, 1.0), 2.0);
@@ -515,13 +516,13 @@ mod tests {
 
     #[test]
     fn test_beta_inc() {
-        beta_assert_relative_eq(beta_inc(0.5, 0.5, 0.5), core::f64::consts::FRAC_PI_2);
-        beta_assert_relative_eq(beta_inc(0.5, 0.5, 1.0), core::f64::consts::PI);
+        beta_assert_relative_eq(beta_inc(0.5, 0.5, 0.5), f64_consts::FRAC_PI_2);
+        beta_assert_relative_eq(beta_inc(0.5, 0.5, 1.0), f64_consts::PI);
         beta_assert_relative_eq(beta_inc(1.0, 0.5, 0.5), 0.5857864376269049511983);
         beta_assert_relative_eq(beta_inc(1.0, 0.5, 1.0), 2.0);
         beta_assert_relative_eq(beta_inc(2.5, 0.5, 0.5), 0.0890486225480862322117);
         beta_assert_relative_eq(beta_inc(2.5, 0.5, 1.0), 1.17809724509617246442);
-        beta_assert_relative_eq(beta_inc(0.5, 1.0, 0.5), core::f64::consts::SQRT_2);
+        beta_assert_relative_eq(beta_inc(0.5, 1.0, 0.5), f64_consts::SQRT_2);
         beta_assert_relative_eq(beta_inc(0.5, 1.0, 1.0), 2.0);
         beta_assert_relative_eq(beta_inc(1.0, 1.0, 0.5), 0.5);
         beta_assert_relative_eq(beta_inc(1.0, 1.0, 1.0), 1.0);
@@ -587,7 +588,7 @@ mod tests {
         assert_eq!(beta_reg(1.0, 0.5, 1.0), 1.0);
         beta_assert_abs_diff_eq(beta_reg(2.5, 0.5, 0.5), 0.07558681842161243795);
         assert_eq!(beta_reg(2.5, 0.5, 1.0), 1.0);
-        beta_assert_abs_diff_eq(beta_reg(0.5, 1.0, 0.5), core::f64::consts::FRAC_1_SQRT_2);
+        beta_assert_abs_diff_eq(beta_reg(0.5, 1.0, 0.5), f64_consts::FRAC_1_SQRT_2);
         assert_eq!(beta_reg(0.5, 1.0, 1.0), 1.0);
         beta_assert_abs_diff_eq(beta_reg(1.0, 1.0, 0.5), 0.5);
         assert_eq!(beta_reg(1.0, 1.0, 1.0), 1.0);

--- a/src/function/erf.rs
+++ b/src/function/erf.rs
@@ -2,7 +2,6 @@
 //! related functions
 
 use crate::function::evaluate;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -740,7 +739,6 @@ fn erf_inv_impl(p: f64, q: f64, s: f64) -> f64 {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use core::f64;
     use super::*;
     use crate::prec;
 

--- a/src/function/evaluate.rs
+++ b/src/function/evaluate.rs
@@ -17,7 +17,6 @@ pub fn polynomial(z: f64, coeff: &[f64]) -> f64 {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use core::f64;
 
     // these tests probably could be more robust
     #[test]

--- a/src/function/gamma.rs
+++ b/src/function/gamma.rs
@@ -386,7 +386,7 @@ pub fn digamma(x: f64) -> f64 {
     if x == f64::NEG_INFINITY || x.is_nan() {
         return f64::NAN;
     }
-    if x <= 0.0 && prec::ulps_eq!(x.floor(), x) {
+    if x <= 0.0 && x.floor() == x {
         return f64::NEG_INFINITY;
     }
     if x < 0.0 {
@@ -1279,6 +1279,11 @@ mod tests {
             2.2622143570941481235561593642219403924532310597356171,
             epsilon = 1e-14
         );
+    }
+
+    #[test]
+    fn test_digamma_near_negative_integer_is_finite() {
+        assert!(super::digamma(-1.0 + 5e-10).is_finite());
     }
 
     #[test]

--- a/src/function/gamma.rs
+++ b/src/function/gamma.rs
@@ -3,6 +3,7 @@
 
 use crate::consts;
 use crate::prec;
+use core::f64::consts as f64_consts;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -61,10 +62,10 @@ pub fn ln_gamma(x: f64) -> f64 {
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (t.0 as f64 - x));
 
         consts::LN_PI
-            - (core::f64::consts::PI * x).sin().ln()
+            - (f64_consts::PI * x).sin().ln()
             - s.ln()
             - consts::LN_2_SQRT_E_OVER_PI
-            - (0.5 - x) * ((0.5 - x + GAMMA_R) / core::f64::consts::E).ln()
+            - (0.5 - x) * ((0.5 - x + GAMMA_R) / f64_consts::E).ln()
     } else {
         let s = GAMMA_DK
             .iter()
@@ -74,7 +75,7 @@ pub fn ln_gamma(x: f64) -> f64 {
 
         s.ln()
             + consts::LN_2_SQRT_E_OVER_PI
-            + (x - 0.5) * ((x - 0.5 + GAMMA_R) / core::f64::consts::E).ln()
+            + (x - 0.5) * ((x - 0.5 + GAMMA_R) / f64_consts::E).ln()
     }
 }
 
@@ -90,11 +91,11 @@ pub fn gamma(x: f64) -> f64 {
             .skip(1)
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (t.0 as f64 - x));
 
-        core::f64::consts::PI
-            / ((core::f64::consts::PI * x).sin()
+        f64_consts::PI
+            / ((f64_consts::PI * x).sin()
                 * s
                 * consts::TWO_SQRT_E_OVER_PI
-                * ((0.5 - x + GAMMA_R) / core::f64::consts::E).powf(0.5 - x))
+                * ((0.5 - x + GAMMA_R) / f64_consts::E).powf(0.5 - x))
     } else {
         let s = GAMMA_DK
             .iter()
@@ -102,7 +103,7 @@ pub fn gamma(x: f64) -> f64 {
             .skip(1)
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (x + t.0 as f64 - 1.0));
 
-        s * consts::TWO_SQRT_E_OVER_PI * ((x - 0.5 + GAMMA_R) / core::f64::consts::E).powf(x - 0.5)
+        s * consts::TWO_SQRT_E_OVER_PI * ((x - 0.5 + GAMMA_R) / f64_consts::E).powf(x - 0.5)
     }
 }
 
@@ -389,7 +390,7 @@ pub fn digamma(x: f64) -> f64 {
         return f64::NEG_INFINITY;
     }
     if x < 0.0 {
-        return digamma(1.0 - x) + core::f64::consts::PI / (-core::f64::consts::PI * x).tan();
+        return digamma(1.0 - x) + f64_consts::PI / (-f64_consts::PI * x).tan();
     }
     if x <= s {
         return d1 - 1.0 / x + d2 * x;
@@ -620,7 +621,7 @@ mod tests {
         );
         prec::assert_abs_diff_eq!(
             super::ln_gamma(3.0),
-            core::f64::consts::LN_2,
+            f64_consts::LN_2,
             epsilon = 1e-14
         );
         prec::assert_abs_diff_eq!(

--- a/src/function/gamma.rs
+++ b/src/function/gamma.rs
@@ -3,7 +3,6 @@
 
 use crate::consts;
 use crate::prec;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 
@@ -62,10 +61,10 @@ pub fn ln_gamma(x: f64) -> f64 {
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (t.0 as f64 - x));
 
         consts::LN_PI
-            - (f64::consts::PI * x).sin().ln()
+            - (core::f64::consts::PI * x).sin().ln()
             - s.ln()
             - consts::LN_2_SQRT_E_OVER_PI
-            - (0.5 - x) * ((0.5 - x + GAMMA_R) / f64::consts::E).ln()
+            - (0.5 - x) * ((0.5 - x + GAMMA_R) / core::f64::consts::E).ln()
     } else {
         let s = GAMMA_DK
             .iter()
@@ -75,7 +74,7 @@ pub fn ln_gamma(x: f64) -> f64 {
 
         s.ln()
             + consts::LN_2_SQRT_E_OVER_PI
-            + (x - 0.5) * ((x - 0.5 + GAMMA_R) / f64::consts::E).ln()
+            + (x - 0.5) * ((x - 0.5 + GAMMA_R) / core::f64::consts::E).ln()
     }
 }
 
@@ -91,11 +90,11 @@ pub fn gamma(x: f64) -> f64 {
             .skip(1)
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (t.0 as f64 - x));
 
-        f64::consts::PI
-            / ((f64::consts::PI * x).sin()
+        core::f64::consts::PI
+            / ((core::f64::consts::PI * x).sin()
                 * s
                 * consts::TWO_SQRT_E_OVER_PI
-                * ((0.5 - x + GAMMA_R) / f64::consts::E).powf(0.5 - x))
+                * ((0.5 - x + GAMMA_R) / core::f64::consts::E).powf(0.5 - x))
     } else {
         let s = GAMMA_DK
             .iter()
@@ -103,7 +102,7 @@ pub fn gamma(x: f64) -> f64 {
             .skip(1)
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (x + t.0 as f64 - 1.0));
 
-        s * consts::TWO_SQRT_E_OVER_PI * ((x - 0.5 + GAMMA_R) / f64::consts::E).powf(x - 0.5)
+        s * consts::TWO_SQRT_E_OVER_PI * ((x - 0.5 + GAMMA_R) / core::f64::consts::E).powf(x - 0.5)
     }
 }
 
@@ -390,7 +389,7 @@ pub fn digamma(x: f64) -> f64 {
         return f64::NEG_INFINITY;
     }
     if x < 0.0 {
-        return digamma(1.0 - x) + f64::consts::PI / (-f64::consts::PI * x).tan();
+        return digamma(1.0 - x) + core::f64::consts::PI / (-core::f64::consts::PI * x).tan();
     }
     if x <= s {
         return d1 - 1.0 / x + d2 * x;
@@ -621,7 +620,7 @@ mod tests {
         );
         prec::assert_abs_diff_eq!(
             super::ln_gamma(3.0),
-            f64::consts::LN_2,
+            core::f64::consts::LN_2,
             epsilon = 1e-14
         );
         prec::assert_abs_diff_eq!(

--- a/src/function/harmonic.rs
+++ b/src/function/harmonic.rs
@@ -35,7 +35,6 @@ pub fn gen_harmonic(n: u64, m: f64) -> f64 {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use core::f64;
     use crate::prec;
     use super::*;
 

--- a/src/function/logistic.rs
+++ b/src/function/logistic.rs
@@ -30,7 +30,6 @@ pub fn checked_logit(p: f64) -> Option<f64> {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use core::f64;
     use crate::prec;
     use super::*;
 

--- a/src/statistics/iter_statistics.rs
+++ b/src/statistics/iter_statistics.rs
@@ -1,6 +1,5 @@
 use crate::statistics::*;
 use core::borrow::Borrow;
-use core::f64;
 #[cfg(not(feature = "std"))]
 use num_traits::Float as _;
 

--- a/src/statistics/slice_statistics.rs
+++ b/src/statistics/slice_statistics.rs
@@ -133,7 +133,7 @@ impl<D: AsMut<[f64]> + AsRef<[f64]>> OrderStatistics<f64> for Data<D> {
         if hf <= 0 || tau == 0.0 {
             return self.min();
         }
-        if hf >= self.len() as i64 || crate::prec::ulps_eq!(tau, 1.0) {
+        if hf >= self.len() as i64 || tau == 1.0 {
             return self.max();
         }
 

--- a/src/statistics/statistics.rs
+++ b/src/statistics/statistics.rs
@@ -25,7 +25,6 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -48,7 +47,6 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -71,7 +69,6 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -94,7 +91,6 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -120,7 +116,6 @@ pub trait Statistics<T> {
     /// ```
     /// use approx::assert_abs_diff_eq;
     ///
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -149,7 +144,6 @@ pub trait Statistics<T> {
     /// ```
     /// use approx::assert_abs_diff_eq;
     ///
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -187,7 +181,6 @@ pub trait Statistics<T> {
     /// ```
     /// use approx::assert_abs_diff_eq;
     ///
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -223,7 +216,6 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -251,7 +243,6 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -277,7 +268,6 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -303,7 +293,6 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -337,7 +326,6 @@ pub trait Statistics<T> {
     /// ```
     /// use approx::assert_abs_diff_eq;
     ///
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -373,7 +361,6 @@ pub trait Statistics<T> {
     /// ```
     /// use approx::assert_abs_diff_eq;
     ///
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -402,7 +389,6 @@ pub trait Statistics<T> {
     /// ```
     /// use approx::assert_abs_diff_eq;
     ///
-    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {

--- a/src/stats_tests/ks_test.rs
+++ b/src/stats_tests/ks_test.rs
@@ -1,7 +1,6 @@
 //! Provides the [Kolmogorov-Smirnov (KS) test](https://en.wikipedia.org/wiki/Kolmogorov–Smirnov_test) and related
 //! functions
 
-use core::f64;
 use core::iter::zip;
 
 use num_traits::clamp;


### PR DESCRIPTION
## Summary

This PR fixes regressions caused by using approximate floating-point equality for conditions that represent exact distribution boundaries or degenerate parameter values.

It includes the `Beta::sf` fix from #436 and extends the correction to the other affected distributions and functions.

## Root cause

`prec::ulps_eq!` uses a default absolute epsilon of `1e-9`. As a result, values close to exact boundaries, such as `p ≈ 1`, `shape ≈ 1`, or `x ≈ 1`, were incorrectly treated as exactly equal.

This caused nearby valid inputs to enter special-case branches intended only for exact mathematical identities or degenerate distributions.

## Regression coverage added

The new tests cover:

- `Beta::sf` for tiny `x` values from `1e-16` down to `1e-100`, using high-precision reference values.
- `Beta::ln_pdf` at `x = 1.0 - 1e-9` for multiple shape combinations.
- Correct `Beta::ln_pdf` infinities at `x = 0` and `x = 1`.
- `Beta` parameters close to, but not exactly, the uniform distribution for CDF, SF and PDF.
- `Binomial` with `p = 1.0 - 5e-10`, including PMF, log-PMF and entropy.
- Finite `Binomial` entropy for `n = 1000` when very small PMF terms underflow to zero.
- `Geometric` with probability close to one, including maximum support, log-PMF, skewness and inverse CDF.
- `Gamma` and `Weibull` densities at zero for shapes immediately above and below one.
- The exact special point of `Gamma` with an infinite rate.
- `InverseGamma` with shape close to one, checked against the general density formula.
- `digamma` close to, but not exactly at, a negative integer pole.
- `Weibull` mode for shapes below one.


## Credits

Thanks to @FBruzzesi for reporting the `Beta::ln_pdf` regression in #437 and for preparing the `Beta::sf` fix in #436, which is included in this PR. (cherry picked)

Closes #437.
Includes and extends #436.