### PR TITLE
Support KDE in no_std

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Check no_std with nalgebra and rand
         run: cargo check --target riscv32imac-unknown-none-elf --no-default-features --features nalgebra,rand --lib
 
+      - name: Check no_std with KDE
+        run: cargo check --target riscv32imac-unknown-none-elf --no-default-features --features kde --lib
+
   features:
     needs: [clippy, fmt]
     runs-on: ubuntu-latest

--- a/Cargo.lock.MSRV
+++ b/Cargo.lock.MSRV
@@ -348,10 +348,10 @@ dependencies = [
 [[package]]
 name = "kdtree"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd666c2aae5dde60d2f9bfa4e1f8c17698fce13d599c0f9b76725641fec13d9"
+source = "git+https://github.com/mrhooray/kdtree-rs?rev=db9af2f8e987c4f1c21251998f032b89a8bd2d52#db9af2f8e987c4f1c21251998f032b89a8bd2d52"
 dependencies = [
  "num-traits",
+ "serde",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ required-features = ["rand", "std", "kde"]
 
 [features]
 default = ["std", "nalgebra", "rand"]
-std = ["approx/std", "num-traits/std", "nalgebra?/std", "rand?/std"]
+std = ["approx/std", "num-traits/std", "nalgebra?/std", "rand?/std", "kdtree?/std"]
 nalgebra = ["dep:nalgebra", "nalgebra/alloc", "nalgebra/libm"]
 rand = ["dep:rand", "nalgebra?/rand-no-std", "rand?/std_rng"]
 # kd-tree backed density estimation (src/density), implemented in terms of nalgebra vectors
-kde = ["dep:kdtree", "nalgebra", "std"]
+kde = ["dep:kdtree", "kdtree/libm", "nalgebra"]
 
 [dependencies]
 approx = { version = "0.5.0", default-features = false }
@@ -54,7 +54,10 @@ default-features = false
 
 [dependencies.kdtree]
 version = "0.8.1"
+git = "https://github.com/mrhooray/kdtree-rs"
+rev = "db9af2f8e987c4f1c21251998f032b89a8bd2d52"
 optional = true
+default-features = false
 
 [dev-dependencies]
 criterion = "0.8"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ matrix-backed distributions without `std`, enable `nalgebra` directly:
 statrs = { version = "*", default-features = false, features = ["nalgebra"] }
 ```
 
+To enable kernel density estimation without `std`, enable `kde`:
+
+```toml
+[dependencies]
+statrs = { version = "*", default-features = false, features = ["kde"] }
+```
+
 Heap-backed APIs use Rust's `alloc` crate. A `no_std` application that calls
 these APIs must provide and initialize a global allocator suitable for its
 target:

--- a/src/density/kde.rs
+++ b/src/density/kde.rs
@@ -1,4 +1,6 @@
 use kdtree::distance::squared_euclidean;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 use crate::{
     density::{Container, DensityError, nearest_neighbors, neighborhood_radius},

--- a/src/density/knn.rs
+++ b/src/density/knn.rs
@@ -4,6 +4,8 @@ use crate::{
     function::gamma::gamma,
 };
 use core::f64::consts::PI;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// Computes the `k`-nearest neighbor density estimate for a given point `x`
 /// using the samples provided.

--- a/src/density/mod.rs
+++ b/src/density/mod.rs
@@ -16,6 +16,8 @@ pub mod kde;
 pub mod knn;
 use alloc::vec::Vec;
 use kdtree::{ErrorKind, KdTree, distance::squared_euclidean};
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 use thiserror::Error;
 
 /// Errors that can occur when estimating a density from a sample.

--- a/tests/no_std/Cargo.toml
+++ b/tests/no_std/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 dlmalloc = { version = "0.2.14", features = ["global"] }
-statrs = { path = "../..", default-features = false, features = ["nalgebra"] }
+statrs = { path = "../..", default-features = false, features = ["kde"] }
 
 [profile.dev]
 panic = "abort"

--- a/tests/no_std/src/lib.rs
+++ b/tests/no_std/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 use alloc::vec;
+use statrs::density::{kde::kde_pdf, knn::knn_pdf};
 use statrs::distribution::{Categorical, Continuous, Empirical, Multinomial, MultivariateNormal};
 use statrs::generate::log_spaced;
 use statrs::statistics::{Data, Distribution, MeanN, OrderStatistics, RankTieBreaker};
@@ -22,6 +23,10 @@ fn assert_close(actual: f64, expected: f64, tolerance: f64) {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn verify() {
+    let kde_samples = vec![[-1.0], [0.0], [1.0]];
+    assert!(kde_pdf(&[0.0], &kde_samples, Some(1.0)).unwrap() > 0.0);
+    assert!(knn_pdf(&[0.0], &kde_samples, Some(1.0)).unwrap() > 0.0);
+
     let categorical = Categorical::new(&[1.0, 2.0, 3.0]).unwrap();
     assert_close(categorical.mean().unwrap(), 4.0 / 3.0, 1e-12);
 


### PR DESCRIPTION
## Motivation

KDE is currently gated by `std` because `kdtree` does not expose its allocation-backed API in `no_std` builds. This continues the `no_std` work tracked in #400 and integrates the upstream support from [mrhooray/kdtree-rs#92](https://github.com/mrhooray/kdtree-rs/pull/92).

## Changes

- enable `kde` with `no_std + alloc` through the upstream `kdtree` `libm` feature
- import `num_traits::Float` where density calculations need floating-point methods without `std`
- compute the neighborhood radius from the farthest returned distance instead of assuming `kdtree::within` result ordering
- add a bare-metal KDE check and execute `kde_pdf` and `knn_pdf` in the existing `no_std` Wasm runtime test
- document the supported `no_std` feature combination

## Blocked by

- [ ] merge and release [mrhooray/kdtree-rs#92](https://github.com/mrhooray/kdtree-rs/pull/92)
- [ ] replace the temporary Git revision with the released crates.io version before merge
