### PR TITLE
fix: keep the left tail of LogNormal::pdf

### DIFF
--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -640,18 +640,15 @@ mod tests {
             (0.0, 5.0, 1.38e-87, 2.07338102578635509e-262),
         ];
 
-        let mut bad = alloc::vec::Vec::new();
         for (location, scale, x, expected) in cases {
             let d = create_ok(location, scale);
             let got = d.pdf(x);
             let rel = ((got - expected) / expected).abs();
-            if !prec::relative_eq!(got, expected, epsilon = 0.0, max_relative = 1e-12) {
-                bad.push(alloc::format!(
-                    "LogNormal({location}, {scale}).pdf({x:e}): got {got:e}, expected {expected:e}, rel err {rel:e}"
-                ));
-            }
+            assert!(
+                prec::relative_eq!(got, expected, epsilon = 0.0, max_relative = 1e-12),
+                "LogNormal({location}, {scale}).pdf({x:e}): got {got:e}, expected {expected:e}, rel err {rel:e}"
+            );
         }
-        assert!(bad.is_empty(), "{}", bad.join("\n"));
     }
 
     #[test]

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -335,20 +335,20 @@ impl Continuous<f64, f64> for LogNormal {
         if x <= 0.0 || x.is_infinite() {
             0.0
         } else {
-            let ln_x = x.ln();
-            let d = (ln_x - self.location) / self.scale;
-            let exponent = -0.5 * d * d;
-            let num = exponent.exp();
-            if num.is_normal() {
-                num / (x * consts::SQRT_2PI * self.scale)
+            let d = (x.ln() - self.location) / self.scale;
+            let numer = (-0.5 * d * d).exp();
+            // grouped so that a subnormal `x` is rounded once instead of twice
+            let denom = x * (consts::SQRT_2PI * self.scale);
+            if numer.is_normal() && denom.is_normal() {
+                numer / denom
             } else {
-                // `num` underflows to zero, or to a subnormal holding only a few
-                // significant bits, long before the density itself does. Divide in
-                // log space instead and exponentiate once. This is `ln_pdf`'s
-                // formula with `ln(x * σ)` split into `ln(x) + ln(σ)`, because
-                // `(x * self.scale).ln()` is `-inf` once `x * σ` underflows, which
-                // would make `pdf` return `inf` where it should return zero.
-                (exponent - consts::LN_SQRT_2PI - ln_x - self.scale.ln()).exp()
+                // Either end of the quotient has left the range where dividing is
+                // accurate: `numer` underflows to zero, or to a subnormal holding
+                // only a few significant bits, long before the density itself does,
+                // and `denom` overflows to infinity or underflows for extreme `x`.
+                // Both collapse the quotient to zero where the density is still a
+                // representable f64, so divide in log space and exponentiate once.
+                self.ln_pdf(x).exp()
             }
         }
     }
@@ -367,8 +367,20 @@ impl Continuous<f64, f64> for LogNormal {
         if x <= 0.0 || x.is_infinite() {
             f64::NEG_INFINITY
         } else {
-            let d = (x.ln() - self.location) / self.scale;
-            (-0.5 * d * d) - consts::LN_SQRT_2PI - (x * self.scale).ln()
+            let ln_x = x.ln();
+            let d = (ln_x - self.location) / self.scale;
+            let x_scale = x * self.scale;
+            // `x * σ` overflows to infinity or underflows to zero at the extremes
+            // of the support, and `ln` then hands back `±inf`, so `ln(xσ)` is split
+            // into `ln(x) + ln(σ)` there. Everywhere else the product keeps its
+            // full precision and is the more accurate of the two, because it only
+            // rounds once and `ln(x)` and `ln(σ)` can be much larger than the sum.
+            let ln_x_scale = if x_scale.is_normal() {
+                x_scale.ln()
+            } else {
+                ln_x + self.scale.ln()
+            };
+            (-0.5 * d * d) - consts::LN_SQRT_2PI - ln_x_scale
         }
     }
 }
@@ -593,7 +605,7 @@ mod tests {
         test_absolute(-0.1, 1.5, 0.90492497850024368541682348133921492204585092983646, 1e-15, pdf(0.1));
         test_absolute(-0.1, 1.5, 0.49191985207660942803818797602364034466489243416574, 1e-16, pdf(0.5));
         test_exact(-0.1, 1.5, 0.33133347214343229148978298237579567194870525187207, pdf(0.8));
-        test_exact(-0.1, 2.5, 1.0824698632626565182080576574958317806389057196768, pdf(0.1));
+        test_absolute(-0.1, 2.5, 1.0824698632626565182080576574958317806389057196768, 1e-15, pdf(0.1));
         test_absolute(-0.1, 2.5, 0.31029619474753883558901295436486123689563749784867, 1e-16, pdf(0.5));
         test_absolute(-0.1, 2.5, 0.19922929916156673799861939824205622734205083805245, 1e-16, pdf(0.8));
 
@@ -608,7 +620,7 @@ mod tests {
         test_absolute(1.5, 1.5, 0.17185785323404088913982425377565512294017306418953, 1e-16, pdf(0.8));
         test_absolute(1.5, 2.5, 0.50186885259059181992025035649158160252576845315332, 1e-15, pdf(0.1));
         test_absolute(1.5, 2.5, 0.21721369314437986034957451699565540205404697589349, 1e-16, pdf(0.5));
-        test_exact(1.5, 2.5, 0.15729636000661278918949298391170443742675565300598, pdf(0.8));
+        test_absolute(1.5, 2.5, 0.15729636000661278918949298391170443742675565300598, 1e-16, pdf(0.8));
         test_exact(2.5, 0.1, 5.6836826548848916385760779034504046896805825555997e-500, pdf(0.1));
         test_absolute(2.5, 0.1, 3.1225608678589488061206338085285607881363155340377e-221, 1e-233, pdf(0.5));
         test_absolute(2.5, 0.1, 4.6994713794671660918554320071312374073172560048297e-161, 1e-173, pdf(0.8));
@@ -674,6 +686,9 @@ mod tests {
         test_exact(0.0, 15.0, 0.0, pdf(1e250));
         test_exact(0.0, 15.0, 0.0, pdf(1e300));
         test_exact(2.5, 10.0, 0.0, pdf(1e200));
+        // exp(-d^2/2) underflows and x * sigma * sqrt(2 pi) overflows at the same
+        // time here, which a naive inf / inf would turn into a NaN
+        test_exact(0.0, 1.0, 0.0, pdf(f64::MAX));
     }
 
     #[test]
@@ -684,6 +699,85 @@ mod tests {
         test_exact(0.0, 1.0, 0.0, pdf(f64::NEG_INFINITY));
         test_exact(0.0, 1.0, 0.0, pdf(f64::INFINITY));
         test_is_nan(0.0, 1.0, pdf(f64::NAN));
+        // an infinite scale is accepted by ::new, and spreads the density to zero
+        test_exact(0.0, f64::INFINITY, 0.0, pdf(1.0));
+    }
+
+    #[test]
+    fn test_pdf_denominator_overflow() {
+        // x * sigma * sqrt(2 pi) overflows to infinity for x near f64::MAX, which
+        // collapses the quotient to zero even though exp(-d^2/2) is an ordinary
+        // float and the density is still representable. Expected values are exact
+        // arithmetic at 150 decimal digits on the binary64 inputs, rounded to
+        // binary64, from pdf(x) = exp(-((ln x - mu)/sigma)^2 / 2) / (x * sigma * sqrt(2 pi)).
+        // The density is subnormal, so 1e-12 is far tighter than the 1.0 that the
+        // plain quotient is off by, and still loose enough for the log-space path,
+        // whose absolute error is a few ulp of |ln_pdf| ~ 710.
+        let got = create_ok(709.0, 1.0).pdf(f64::MAX);
+        prec::assert_relative_eq!(got, 1.6336594696904199462e-309,
+            epsilon = 0.0, max_relative = 1e-12);
+    }
+
+    #[test]
+    fn test_pdf_denominator_underflow() {
+        // The mirror image: x * sigma * sqrt(2 pi) is subnormal for x near
+        // f64::MIN_POSITIVE, so the quotient divides by a denominator that holds
+        // only a handful of significant bits. Dividing directly is off by 2.8e-4
+        // here. Expected value is exact arithmetic at 150 decimal digits on the
+        // binary64 inputs. 1e-10 leaves room for the log-space path, which sums
+        // terms of size |ln x| ~ 737, and for a platform `ln` or `exp` that is an
+        // ulp or two off; the plain quotient misses by 2.8e-4 either way.
+        let got = create_ok(-747.0, 0.5).pdf(1e-320);
+        prec::assert_relative_eq!(got, 1.0375087109168858740e230,
+            epsilon = 0.0, max_relative = 1e-10);
+    }
+
+    #[test]
+    fn test_pdf_guard_boundaries() {
+        // Straddles both switches between the quotient and the log-space path, so
+        // the density stays continuous across them. For location 0 and scale 1 the
+        // numerator leaves the normal range just below x = 4.5e-17; for location
+        // 709 and scale 1 the denominator overflows just above x = 7.17e307.
+        // Expected values are exact arithmetic at 150 decimal digits on the
+        // binary64 inputs, rounded to binary64.
+        let cases = [
+            (0.0, 1.0, 5e-17, 9.4703106003006510660e-291),     // quotient
+            (0.0, 1.0, 4e-17, 2.6606766015573320120e-294),     // log space
+            (709.0, 1.0, 7e307, 5.6262704857806850227e-309),   // quotient
+            (709.0, 1.0, 7.3e307, 5.4267255927382909466e-309), // log space
+        ];
+
+        for (location, scale, x, expected) in cases {
+            let got = create_ok(location, scale).pdf(x);
+            prec::assert_relative_eq!(got, expected, epsilon = 0.0, max_relative = 1e-12);
+        }
+    }
+
+    #[test]
+    fn test_ln_pdf_extreme_x() {
+        // x * sigma underflows to zero for subnormal x and overflows to infinity
+        // for x near f64::MAX, and ln of either flips the sign of the result: the
+        // first and last of these used to come back as +inf and -inf. The middle
+        // one keeps x * sigma subnormal but nonzero, and has to stay put. Expected
+        // values are exact arithmetic at 150 decimal digits on the binary64
+        // inputs, rounded to binary64, from
+        // ln_pdf(x) = -((ln x - mu)/sigma)^2 / 2 - ln(sqrt(2 pi)) - ln x - ln sigma.
+        let cases = [
+            (0.0, 0.25, 5e-324, -4432783.2580307411557),
+            (0.0, 1.0, 1e-320, -270721.28315714487534),
+            (0.0, 1e10, f64::MAX, -733.72750235652912883),
+        ];
+
+        for (location, scale, x, expected) in cases {
+            let got = create_ok(location, scale).ln_pdf(x);
+            prec::assert_relative_eq!(got, expected, epsilon = 0.0, max_relative = 1e-14);
+        }
+
+        // an infinite scale is accepted by ::new; x * sigma is then infinite for
+        // every x, and the log density is -inf rather than +inf
+        let ln_pdf = |arg: f64| move |x: LogNormal| x.ln_pdf(arg);
+        test_exact(0.0, f64::INFINITY, f64::NEG_INFINITY, ln_pdf(1.0));
+        test_is_nan(0.0, 1.0, ln_pdf(f64::NAN));
     }
 
     #[test]

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -335,8 +335,21 @@ impl Continuous<f64, f64> for LogNormal {
         if x <= 0.0 || x.is_infinite() {
             0.0
         } else {
-            let d = (x.ln() - self.location) / self.scale;
-            (-0.5 * d * d).exp() / (x * consts::SQRT_2PI * self.scale)
+            let ln_x = x.ln();
+            let d = (ln_x - self.location) / self.scale;
+            let exponent = -0.5 * d * d;
+            let num = exponent.exp();
+            if num.is_normal() {
+                num / (x * consts::SQRT_2PI * self.scale)
+            } else {
+                // `num` underflows to zero, or to a subnormal holding only a few
+                // significant bits, long before the density itself does. Divide in
+                // log space instead and exponentiate once. This is `ln_pdf`'s
+                // formula with `ln(x * σ)` split into `ln(x) + ln(σ)`, because
+                // `(x * self.scale).ln()` is `-inf` once `x * σ` underflows, which
+                // would make `pdf` return `inf` where it should return zero.
+                (exponent - consts::LN_SQRT_2PI - ln_x - self.scale.ln()).exp()
+            }
         }
     }
 
@@ -365,6 +378,7 @@ impl Continuous<f64, f64> for LogNormal {
 mod tests {
     use super::*;
     use crate::distribution::internal::density_util;
+    use crate::prec;
 
     testing_boiler!(location: f64, scale: f64; LogNormal; LogNormalError);
 
@@ -610,6 +624,69 @@ mod tests {
     fn test_neg_pdf() {
         let pdf = |arg: f64| move |x: LogNormal| x.pdf(arg);
         test_exact(0.0, 1.0, 0.0, pdf(0.0));
+    }
+
+    #[test]
+    fn test_pdf_left_tail() {
+        // Expected values are exact arithmetic at 80 decimal digits, rounded to
+        // binary64, from pdf(x) = exp(-((ln x - mu)/sigma)^2 / 2) / (x * sigma * sqrt(2 pi)).
+        // Not SciPy: SciPy computes this the same way we do, so it agrees with us
+        // rather than checking us.
+        // Each density is an ordinary (non-subnormal) f64, far above the
+        // underflow threshold of the distribution itself.
+        let cases = [
+            (0.0, 15.0, 1e-252, 3.04796856373058623e-75),
+            (0.0, 10.0, 2.24e-168, 4.60596725315129703e-158),
+            (0.0, 5.0, 1.38e-87, 2.07338102578635509e-262),
+        ];
+
+        let mut bad = alloc::vec::Vec::new();
+        for (location, scale, x, expected) in cases {
+            let d = create_ok(location, scale);
+            let got = d.pdf(x);
+            let rel = ((got - expected) / expected).abs();
+            if !prec::relative_eq!(got, expected, epsilon = 0.0, max_relative = 1e-12) {
+                bad.push(alloc::format!(
+                    "LogNormal({location}, {scale}).pdf({x:e}): got {got:e}, expected {expected:e}, rel err {rel:e}"
+                ));
+            }
+        }
+        assert!(bad.is_empty(), "{}", bad.join("\n"));
+    }
+
+    #[test]
+    fn test_pdf_right_tail() {
+        // The same expression covers the right tail. Expected values are exact
+        // arithmetic at 60 decimal digits, rounded to binary64, not SciPy.
+        // These are all reachable without exp(-d^2/2)
+        // underflowing, so they pin the density down where it always worked.
+        let cases = [
+            (0.0, 1.0, 1e5, 6.5856159926167960017e-35),
+            (0.0, 5.0, 1e30, 2.8537004754025084595e-73),
+            (0.0, 15.0, 1e100, 1.8041024017455373079e-153),
+        ];
+
+        for (location, scale, x, expected) in cases {
+            let got = create_ok(location, scale).pdf(x);
+            prec::assert_relative_eq!(got, expected, epsilon = 0.0, max_relative = 1e-13);
+        }
+
+        // further out the density itself underflows, and must stay exactly
+        // zero rather than becoming a NaN or a spurious subnormal
+        let pdf = |arg: f64| move |x: LogNormal| x.pdf(arg);
+        test_exact(0.0, 15.0, 0.0, pdf(1e250));
+        test_exact(0.0, 15.0, 0.0, pdf(1e300));
+        test_exact(2.5, 10.0, 0.0, pdf(1e200));
+    }
+
+    #[test]
+    fn test_pdf_boundaries() {
+        // x = 0.0 is covered by test_neg_pdf
+        let pdf = |arg: f64| move |x: LogNormal| x.pdf(arg);
+        test_exact(0.0, 1.0, 0.0, pdf(-1.0));
+        test_exact(0.0, 1.0, 0.0, pdf(f64::NEG_INFINITY));
+        test_exact(0.0, 1.0, 0.0, pdf(f64::INFINITY));
+        test_is_nan(0.0, 1.0, pdf(f64::NAN));
     }
 
     #[test]


### PR DESCRIPTION
`LogNormal::pdf` computes `exp(-d^2/2) / (x * sigma * sqrt(2 pi))`. Both ends of that quotient leave the representable range long before the density does. The numerator underflows in the tails, and the denominator overflows to infinity or underflows towards zero for extreme `x`. Either one on its own collapses the result.

On main:

```
LogNormal(0, 15).pdf(1e-252)              got 0            expected 3.047968563730586e-75
LogNormal(0, 10).pdf(2.24e-168)           got 8.79927e-158 expected 4.60597e-158
LogNormal(0, 5).pdf(1.38e-87)             got 0            expected 2.073381025786355e-262
LogNormal(ln(f64::MAX), 1).pdf(f64::MAX)  got 0            expected 2.219190097936194e-309
```

`ln_pdf` has a version of the same problem. It forms `(x * self.scale).ln()`, which is `-inf` once the product underflows and `+inf` once it overflows, so it returns `+inf` for `LogNormal(0, 0.25).ln_pdf(5e-324)` and `-inf` for `LogNormal(0, 1e10).ln_pdf(f64::MAX)`.

So `pdf` keeps the value-space expression, guarded now on the numerator and the denominator, and falls back to `ln_pdf(x).exp()` instead of repeating the formula. `ln_pdf` splits `ln(x * sigma)` into `ln(x) + ln(sigma)`, but only where the product is not a normal float. The split is not unconditional because `ln(x * sigma)` rounds once instead of twice and is the more accurate form while the product is in range; unconditional, it moves four existing `test_ln_pdf` rows by a ulp and fails one of them against its 1e-16 tolerance.

Two rows in `test_pdf` move by 1 ULP, because the denominator is grouped as `x * (sqrt(2 pi) * sigma)` now so that a subnormal `x` is rounded once instead of twice. Those two are `test_absolute` with the expected values untouched. Nothing else in the existing suite changed.

Tests cover the left tail, the right tail, both denominator extremes, the boundaries either side of each guard, and `ln_pdf` at both ends. Expected values are exact arithmetic on the binary64 inputs rather than SciPy, following 10cf6d6. `cargo test` is green at 803 passed, as are `cargo fmt -- --check`, clippy under `-Dwarnings`, and `cargo check --no-default-features --lib`.

The same exponentiate-then-divide shape appears in nine other distributions. I filed that separately as #453 rather than widen this.

Fixes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log-normal probability density calculations for extreme tail values.
  * Prevented valid finite densities from being reported as infinite or lost due to numerical underflow.
  * Improved handling of boundary conditions and invalid numeric inputs, including NaN values.
* **Tests**
  * Added coverage for left-tail, right-tail, underflow, boundary, and NaN scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
